### PR TITLE
feature/oney-set-company

### DIFF
--- a/src/Action/ConvertPaymentAction.php
+++ b/src/Action/ConvertPaymentAction.php
@@ -201,6 +201,18 @@ final class ConvertPaymentAction implements ActionInterface, ApiAwareInterface
         $details['authorized_amount'] = $details['amount'];
         unset($details['amount']);
 
+        $billing = $details['billing'];
+        if ($billing['company_name'] === null) {
+            $billing['company_name'] = \sprintf('%s %s', $billing['first_name'], $billing['last_name']);
+        }
+        $details['billing'] = $billing;
+
+        $shipping = $details['shipping'];
+        if ($shipping['company_name'] === null) {
+            $shipping['company_name'] = \sprintf('%s %s', $shipping['first_name'], $shipping['last_name']);
+        }
+        $details['shipping'] = $shipping;
+
         return $details;
     }
 


### PR DESCRIPTION
When sending an Oney Payment, Company is mandatory. As it's not mandatory in checkout process, we fill it with firstName and lastName. 

Note: the error raised in PaymentTypeExtension is already removed in #54 