### PR TITLE
fix/change payment method

### DIFF
--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -80,6 +80,12 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Gateway
             'cancel_url' => $token->getTargetUrl() . '?&' . http_build_query(['status' => PayPlugApiClientInterface::STATUS_CANCELED]),
         ];
 
+        if (isset($details['status']) && $details['status'] === 'pending') {
+            // We previously made a payment but not yet "authorized",
+            // Unset current status to allow to use payplug to change payment method
+            unset($details['status']);
+        }
+
         $payment = $this->createPayment($details);
 
         $details['status'] = PayPlugApiClientInterface::STATUS_CREATED;


### PR DESCRIPTION
Refs JIRA#31 - fix change payment method when order payment is still pending

The bug was raising when a status (here `pending`) was already affected to order, and the status was sent to Payplug API that refused this field.