### PR TITLE
fix migration order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3",
         "giggsey/libphonenumber-for-php": "^8.12",
         "payplug/payplug-php": "^3.1",
-        "sylius/refund-plugin": "^1.0.0-RC.8",
+        "sylius/refund-plugin": "1.0.0-RC.9",
         "sylius/sylius": "^1.8.6 || ^v1.9.0",
         "symfony/contracts": "^1.1|^2.0",
         "symfony/lock": "^4.3|^5.0",

--- a/src/Creator/RefundUnitsCommandCreatorDecorator.php
+++ b/src/Creator/RefundUnitsCommandCreatorDecorator.php
@@ -61,8 +61,14 @@ class RefundUnitsCommandCreatorDecorator implements RefundUnitsCommandCreatorInt
 
     public function fromRequest(Request $request): RefundUnits
     {
-        $units = $this->filterEmptyRefundUnits($request->request->get('sylius_refund_units', []));
-        $shipments = $this->filterEmptyRefundUnits($request->request->get('sylius_refund_shipments', []));
+        Assert::true($request->attributes->has('orderNumber'), 'Refunded order number not provided');
+
+        $units = $this->filterEmptyRefundUnits(
+            $request->request->has('sylius_refund_units') ? $request->request->all()['sylius_refund_units'] : []
+        );
+        $shipments = $this->filterEmptyRefundUnits(
+            $request->request->has('sylius_refund_shipments') ? $request->request->all()['sylius_refund_shipments'] : []
+        );
 
         if (count($units) === 0 && count($shipments) === 0) {
             throw InvalidRefundAmount::withValidationConstraint(

--- a/src/DependencyInjection/PayPlugSyliusPayPlugExtension.php
+++ b/src/DependencyInjection/PayPlugSyliusPayPlugExtension.php
@@ -60,6 +60,7 @@ final class PayPlugSyliusPayPlugExtension extends Extension implements PrependEx
     {
         return [
             'Sylius\Bundle\CoreBundle\Migrations',
+            'Sylius\RefundPlugin\Migrations',
         ];
     }
 }


### PR DESCRIPTION
When installing Sylius after adding the Plugin, the migrations are played in the wrong order.
This causes an error because a query references a table that does not yet exist.
This PR corrects this problem.