### PR TITLE
PPSYL-184 - Always add a notification url when create payment

### DIFF
--- a/src/Command/Handler/CapturePaymentRequestHandler.php
+++ b/src/Command/Handler/CapturePaymentRequestHandler.php
@@ -27,7 +27,6 @@ final class CapturePaymentRequestHandler
         private PayPlugPaymentDataCreator $paymentDataCreator,
         #[Autowire(service: 'sylius_shop.provider.order_pay.after_pay_url')]
         private UrlProviderInterface $afterPayUrlProvider,
-        private UrlGeneratorInterface $urlGenerator,
     ) {}
 
     public function __invoke(CapturePaymentRequest $capturePaymentRequest): void
@@ -66,9 +65,6 @@ final class CapturePaymentRequestHandler
             'return_url' => $returnUrl,
             'cancel_url' => $returnUrl . '?&' . http_build_query(['status' => PayPlugApiClientInterface::STATUS_CANCELED]),
         ];
-
-        $notificationUrl = $this->urlGenerator->generate('sylius_payment_method_notify', ['code' => $payment->getMethod()?->getCode()], UrlGeneratorInterface::ABSOLUTE_URL);
-        $data['notification_url'] = $notificationUrl;
 
         $paymentRequest->setPayload($data);
 

--- a/src/Creator/PayPlugPaymentDataCreator.php
+++ b/src/Creator/PayPlugPaymentDataCreator.php
@@ -27,6 +27,7 @@ use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Core\Model\Shipment;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class PayPlugPaymentDataCreator
 {
@@ -41,6 +42,7 @@ class PayPlugPaymentDataCreator
         private RepositoryInterface $payplugCardRepository,
         private RequestStack $requestStack,
         private PayplugFeatureChecker $payplugFeatureChecker,
+        private UrlGeneratorInterface $urlGenerator,
     ) {
     }
 
@@ -82,6 +84,9 @@ class PayPlugPaymentDataCreator
 
         $paymentMethod = $payment->getMethod();
         $gatewayFactoryName = $paymentMethod?->getGatewayConfig()?->getFactoryName();
+
+        $notificationUrl = $this->urlGenerator->generate('sylius_payment_method_notify', ['code' => $payment->getMethod()?->getCode()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $details['notification_url'] = $notificationUrl;
 
         if (
             PayPlugGatewayFactory::FACTORY_NAME === $gatewayFactoryName &&

--- a/src/Provider/Payment/ApplePayPaymentProvider.php
+++ b/src/Provider/Payment/ApplePayPaymentProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PayPlug\SyliusPayPlugPlugin\Provider\Payment;
 
 use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 use Payplug\Resource\IVerifiableAPIResource;
 use Payplug\Resource\Payment;
@@ -32,7 +31,6 @@ use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
 use Sylius\Component\Payment\PaymentTransitions;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
 use Webmozart\Assert\Assert;
 
 class ApplePayPaymentProvider
@@ -45,7 +43,6 @@ class ApplePayPaymentProvider
         #[Autowire('@payplug_sylius_payplug_plugin.api_client.apple_pay')]
         private PayPlugApiClientInterface $applePayClient,
         private OrderTokenAssignerInterface $orderTokenAssigner,
-        private RouterInterface $router,
         private LoggerInterface $logger,
     ) {
     }
@@ -81,7 +78,6 @@ class ApplePayPaymentProvider
         );
 
         $paymentData = $paymentDataObject->getArrayCopy();
-        $paymentData['notification_url'] = $this->router->generate('sylius_payment_method_notify', ['code' => $payment->getMethod()?->getCode()], RouterInterface::ABSOLUTE_URL);
         $this->logger->notice('[Payplug] ApplePay payment data', ['data' => $paymentData]);
 
         $paymentResource = $this->applePayClient->createPayment($paymentData);


### PR DESCRIPTION
It was missing when creating integrated payment.

Let's centralize it when create payment data, so all payments will have the notification url