### PR TITLE
PRE-3349: Retrieve min/max amount for each APM from API

### DIFF
--- a/src/Gateway/AmericanExpressGatewayFactory.php
+++ b/src/Gateway/AmericanExpressGatewayFactory.php
@@ -11,11 +11,4 @@ final class AmericanExpressGatewayFactory extends AbstractGatewayFactory
     public const FACTORY_TITLE = 'American Express by PayPlug';
 
     public const PAYMENT_METHOD_AMERICAN_EXPRESS = 'american_express';
-
-    public const AUTHORIZED_CURRENCIES = [
-        'EUR' => [
-            'min_amount' => 100,
-            'max_amount' => 2000000,
-        ],
-    ];
 }

--- a/src/Gateway/ApplePayGatewayFactory.php
+++ b/src/Gateway/ApplePayGatewayFactory.php
@@ -11,11 +11,4 @@ final class ApplePayGatewayFactory extends AbstractGatewayFactory
     public const FACTORY_TITLE = 'Apple Pay by PayPlug';
 
     public const PAYMENT_METHOD_APPLE_PAY = 'apple_pay';
-
-    public const AUTHORIZED_CURRENCIES = [
-        'EUR' => [
-            'min_amount' => 100,
-            'max_amount' => 2000000,
-        ],
-    ];
 }

--- a/src/Gateway/BancontactGatewayFactory.php
+++ b/src/Gateway/BancontactGatewayFactory.php
@@ -11,11 +11,4 @@ final class BancontactGatewayFactory extends AbstractGatewayFactory
     public const FACTORY_TITLE = 'Bancontact by PayPlug';
 
     public const PAYMENT_METHOD_BANCONTACT = 'bancontact';
-
-    public const AUTHORIZED_CURRENCIES = [
-        'EUR' => [
-            'min_amount' => 100,
-            'max_amount' => 2000000,
-        ],
-    ];
 }

--- a/src/Gateway/PayPlugGatewayFactory.php
+++ b/src/Gateway/PayPlugGatewayFactory.php
@@ -16,11 +16,4 @@ final class PayPlugGatewayFactory extends AbstractGatewayFactory
     public const INTEGRATED_PAYMENT = 'integratedPayment';
 
     public const DEFERRED_CAPTURE = 'deferredCapture';
-
-    public const AUTHORIZED_CURRENCIES = [
-        'EUR' => [
-            'min_amount' => 99,
-            'max_amount' => 2000000,
-        ],
-    ];
 }

--- a/src/Gateway/ScalapayGatewayFactory.php
+++ b/src/Gateway/ScalapayGatewayFactory.php
@@ -11,11 +11,4 @@ final class ScalapayGatewayFactory extends AbstractGatewayFactory
     public const FACTORY_TITLE = 'Scalapay by PayPlug';
 
     public const PAYMENT_METHOD_SCALAPAY = 'scalapay';
-
-    public const AUTHORIZED_CURRENCIES = [
-        'EUR' => [
-            'min_amount' => 500,
-            'max_amount' => 200000,
-        ],
-    ];
 }

--- a/src/Provider/SupportedMethodsProvider.php
+++ b/src/Provider/SupportedMethodsProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PayPlug\SyliusPayPlugPlugin\Provider;
 
+use PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClientFactoryInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Payment\Model\GatewayConfigInterface;
@@ -11,17 +12,19 @@ use Webmozart\Assert\Assert;
 
 final class SupportedMethodsProvider
 {
-    public function __construct(private CurrencyContextInterface $currencyContext)
-    {
+    public function __construct(
+        private CurrencyContextInterface $currencyContext,
+        private PayPlugApiClientFactoryInterface $clientFactory,
+    ) {
     }
 
     public function provide(
         array $supportedMethods,
         string $factoryName,
-        array $authorizedCurrencies,
         int $paymentAmount,
     ): array {
         $activeCurrencyCode = $this->currencyContext->getCurrencyCode();
+        $authorizedCurrencies = null;
 
         foreach ($supportedMethods as $key => $paymentMethod) {
             Assert::isInstanceOf($paymentMethod, PaymentMethodInterface::class);
@@ -32,6 +35,8 @@ final class SupportedMethodsProvider
             if ($factoryName !== $gatewayConfig->getFactoryName()) {
                 continue;
             }
+
+            $authorizedCurrencies ??= $this->resolveAuthorizedCurrencies($factoryName);
 
             if (!\array_key_exists($activeCurrencyCode, $authorizedCurrencies)) {
                 unset($supportedMethods[$key]);
@@ -50,5 +55,42 @@ final class SupportedMethodsProvider
         }
 
         return $supportedMethods;
+    }
+
+    private function resolveAuthorizedCurrencies(string $factoryName): array
+    {
+        $account = $this->clientFactory->create($factoryName)->getAccount();
+
+        $configuration = $account['configuration'] ?? [];
+        Assert::isArray($configuration);
+        $defaultMin = $configuration['min_amounts'] ?? [];
+        Assert::isArray($defaultMin);
+        $defaultMax = $configuration['max_amounts'] ?? [];
+        Assert::isArray($defaultMax);
+
+        $underscorePos = strpos($factoryName, '_');
+        if ($underscorePos !== false) {
+            $pmKey = substr($factoryName, $underscorePos + 1);
+            $paymentMethods = $account['payment_methods'] ?? [];
+            Assert::isArray($paymentMethods);
+            $pmData = $paymentMethods[$pmKey] ?? [];
+            Assert::isArray($pmData);
+            $minAmounts = isset($pmData['min_amounts']) && \is_array($pmData['min_amounts']) ? $pmData['min_amounts'] : $defaultMin;
+            $maxAmounts = isset($pmData['max_amounts']) && \is_array($pmData['max_amounts']) ? $pmData['max_amounts'] : $defaultMax;
+        } else {
+            $minAmounts = $defaultMin;
+            $maxAmounts = $defaultMax;
+        }
+
+        $currencies = [];
+        foreach ($minAmounts as $currency => $min) {
+            Assert::string($currency);
+            Assert::integer($min);
+            if (isset($maxAmounts[$currency]) && \is_int($maxAmounts[$currency])) {
+                $currencies[$currency] = ['min_amount' => $min, 'max_amount' => $maxAmounts[$currency]];
+            }
+        }
+
+        return $currencies;
     }
 }

--- a/src/Resolver/AmericanExpressPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/AmericanExpressPaymentMethodsResolverDecorator.php
@@ -31,7 +31,6 @@ final class AmericanExpressPaymentMethodsResolverDecorator implements PaymentMet
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             AmericanExpressGatewayFactory::FACTORY_NAME,
-            AmericanExpressGatewayFactory::AUTHORIZED_CURRENCIES,
             $subject->getAmount() ?? 0,
         );
     }

--- a/src/Resolver/ApplePayPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/ApplePayPaymentMethodsResolverDecorator.php
@@ -31,7 +31,6 @@ final class ApplePayPaymentMethodsResolverDecorator implements PaymentMethodsRes
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             ApplePayGatewayFactory::FACTORY_NAME,
-            ApplePayGatewayFactory::AUTHORIZED_CURRENCIES,
             $subject->getAmount() ?? 0,
         );
     }

--- a/src/Resolver/BancontactPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/BancontactPaymentMethodsResolverDecorator.php
@@ -31,7 +31,6 @@ final class BancontactPaymentMethodsResolverDecorator implements PaymentMethodsR
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             BancontactGatewayFactory::FACTORY_NAME,
-            BancontactGatewayFactory::AUTHORIZED_CURRENCIES,
             $subject->getAmount() ?? 0,
         );
     }

--- a/src/Resolver/PayPlugPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/PayPlugPaymentMethodsResolverDecorator.php
@@ -31,7 +31,6 @@ final class PayPlugPaymentMethodsResolverDecorator implements PaymentMethodsReso
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             PayPlugGatewayFactory::FACTORY_NAME,
-            PayPlugGatewayFactory::AUTHORIZED_CURRENCIES,
             $subject->getAmount() ?? 0,
         );
     }

--- a/src/Resolver/ScalapayPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/ScalapayPaymentMethodsResolverDecorator.php
@@ -31,7 +31,6 @@ final class ScalapayPaymentMethodsResolverDecorator implements PaymentMethodsRes
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             ScalapayGatewayFactory::FACTORY_NAME,
-            ScalapayGatewayFactory::AUTHORIZED_CURRENCIES,
             $subject->getAmount() ?? 0,
         );
     }

--- a/tests/PHPUnit/Provider/SupportedMethodsProviderTest.php
+++ b/tests/PHPUnit/Provider/SupportedMethodsProviderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Provider;
 
+use PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClientFactoryInterface;
+use PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClientInterface;
 use PayPlug\SyliusPayPlugPlugin\Gateway\BancontactGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
@@ -17,12 +19,21 @@ final class SupportedMethodsProviderTest extends TestCase
 {
     private CurrencyContextInterface&MockObject $currencyContext;
 
+    private PayPlugApiClientFactoryInterface&MockObject $clientFactory;
+
+    private PayPlugApiClientInterface&MockObject $apiClient;
+
     private SupportedMethodsProvider $provider;
 
     protected function setUp(): void
     {
         $this->currencyContext = $this->createMock(CurrencyContextInterface::class);
-        $this->provider = new SupportedMethodsProvider($this->currencyContext);
+        $this->clientFactory = $this->createMock(PayPlugApiClientFactoryInterface::class);
+        $this->apiClient = $this->createMock(PayPlugApiClientInterface::class);
+
+        $this->clientFactory->method('create')->willReturn($this->apiClient);
+
+        $this->provider = new SupportedMethodsProvider($this->currencyContext, $this->clientFactory);
     }
 
     // -------------------------------------------------------------------------
@@ -36,12 +47,12 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withDifferentFactory_doesNotFilter(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(30, 2000000));
 
         // PaymentMethod is PayPlug, but we're querying for Bancontact — so it's passed through as-is
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], BancontactGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 1000);
+        $result = $this->provider->provide([$method], BancontactGatewayFactory::FACTORY_NAME, 1000);
 
         // Method stays in list (it doesn't match the target factory, so the currency/amount check never runs)
         self::assertCount(1, $result);
@@ -52,17 +63,17 @@ final class SupportedMethodsProviderTest extends TestCase
     // -------------------------------------------------------------------------
 
     /**
-     * The current currency is USD but the method only authorises EUR.
+     * The current currency is USD but the method only authorizes EUR.
      * Verifies the method is removed from the result list.
      */
     public function testProvide_withUnauthorizedCurrency_removesMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('USD');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 1000);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 1000);
 
         self::assertEmpty($result);
     }
@@ -78,11 +89,11 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withAmountBelowMin_removesMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 50);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 50);
 
         self::assertEmpty($result);
     }
@@ -98,11 +109,11 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withAmountAboveMax_removesMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 2000001);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 2000001);
 
         self::assertEmpty($result);
     }
@@ -118,11 +129,11 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withValidCurrencyAndAmount_keepsMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 1000);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 1000);
 
         self::assertCount(1, $result);
         self::assertSame($method, reset($result));
@@ -139,11 +150,11 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withAmountAtMinBoundary_keepsMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 99);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 99);
 
         self::assertCount(1, $result);
     }
@@ -159,11 +170,11 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withAmountAtMaxBoundary_keepsMethod(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
-        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, $authorizedCurrencies, 2000000);
+        $result = $this->provider->provide([$method], PayPlugGatewayFactory::FACTORY_NAME, 2000000);
 
         self::assertCount(1, $result);
     }
@@ -179,16 +190,15 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withMixedList_filtersCorrectly(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(99, 2000000));
 
         $payplugMethod = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
         $bancontactMethod = $this->buildPaymentMethod(BancontactGatewayFactory::FACTORY_NAME);
-        $authorizedCurrencies = ['EUR' => ['min_amount' => 99, 'max_amount' => 2000000]];
 
         // We query for PayPlug factory only; amount is valid
         $result = $this->provider->provide(
             [$payplugMethod, $bancontactMethod],
             PayPlugGatewayFactory::FACTORY_NAME,
-            $authorizedCurrencies,
             1000,
         );
 
@@ -197,8 +207,94 @@ final class SupportedMethodsProviderTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // provide() — payment method specific amounts used over configuration defaults
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the account JSON has specific min/max for the payment method,
+     * those values take precedence over the configuration defaults.
+     */
+    public function testProvide_usesPaymentMethodSpecificAmounts(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+
+        // Scalapay has tighter limits (500–200000) vs configuration defaults (30–2000000)
+        $account = [
+            'configuration' => [
+                'min_amounts' => ['EUR' => 30],
+                'max_amounts' => ['EUR' => 2000000],
+            ],
+            'payment_methods' => [
+                'scalapay' => [
+                    'min_amounts' => ['EUR' => 500],
+                    'max_amounts' => ['EUR' => 200000],
+                ],
+            ],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_scalapay');
+
+        // Amount 400 is above the configuration default min (30) but below Scalapay's min (500)
+        $result = $this->provider->provide([$method], 'payplug_scalapay', 400);
+        self::assertEmpty($result);
+
+        // Amount 500 is exactly at Scalapay's min — should be kept
+        $result2 = $this->provider->provide([$method], 'payplug_scalapay', 500);
+        self::assertCount(1, $result2);
+    }
+
+    // -------------------------------------------------------------------------
+    // provide() — fallback to configuration when payment method has no amounts
+    // -------------------------------------------------------------------------
+
+    /**
+     * When the payment method entry in the API has no min/max amounts (e.g. Apple Pay),
+     * the configuration defaults are used.
+     */
+    public function testProvide_fallsBackToConfigurationAmounts(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+
+        $account = [
+            'configuration' => [
+                'min_amounts' => ['EUR' => 30],
+                'max_amounts' => ['EUR' => 2000000],
+            ],
+            'payment_methods' => [
+                'apple_pay' => [
+                    'enabled' => true,
+                    // no min_amounts / max_amounts
+                ],
+            ],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_apple_pay');
+
+        // 30 is at configuration min — should be kept
+        $result = $this->provider->provide([$method], 'payplug_apple_pay', 30);
+        self::assertCount(1, $result);
+
+        // 29 is below configuration min — should be removed
+        $result2 = $this->provider->provide([$method], 'payplug_apple_pay', 29);
+        self::assertEmpty($result2);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    private function buildAccount(int $minAmount, int $maxAmount): array
+    {
+        return [
+            'configuration' => [
+                'min_amounts' => ['EUR' => $minAmount],
+                'max_amounts' => ['EUR' => $maxAmount],
+            ],
+            'payment_methods' => [],
+        ];
+    }
 
     private function buildPaymentMethod(string $factoryName): PaymentMethodInterface
     {


### PR DESCRIPTION
## Description
<!-- Provide a clear summary of the changes and the problem it solves. -->
<!-- Include any relevant context or background information. -->

**Motivation:**
Retrieving Min / Max amounts for each APM from the API instead of setting hardcoded values that won't follow API changes.

**Related issue(s):** Closes #3359

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- [x] 🔧 Refactor (no functional changes, code improvement only)

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
