### PR TITLE
PRE-3365: Get allowed_countries from api + filter display

### DIFF
--- a/src/Provider/SupportedMethodsProvider.php
+++ b/src/Provider/SupportedMethodsProvider.php
@@ -22,9 +22,11 @@ final class SupportedMethodsProvider
         array $supportedMethods,
         string $factoryName,
         int $paymentAmount,
+        ?string $billingCountryCode = null,
     ): array {
         $activeCurrencyCode = $this->currencyContext->getCurrencyCode();
         $authorizedCurrencies = null;
+        $allowedCountries = null;
 
         foreach ($supportedMethods as $key => $paymentMethod) {
             Assert::isInstanceOf($paymentMethod, PaymentMethodInterface::class);
@@ -37,6 +39,13 @@ final class SupportedMethodsProvider
             }
 
             $authorizedCurrencies ??= $this->resolveAuthorizedCurrencies($factoryName);
+            $allowedCountries ??= $this->resolveAllowedCountries($factoryName);
+
+            if ($billingCountryCode !== null && $allowedCountries !== [] && !\in_array($billingCountryCode, $allowedCountries, true)) {
+                unset($supportedMethods[$key]);
+
+                continue;
+            }
 
             if (!\array_key_exists($activeCurrencyCode, $authorizedCurrencies)) {
                 unset($supportedMethods[$key]);
@@ -92,5 +101,29 @@ final class SupportedMethodsProvider
         }
 
         return $currencies;
+    }
+
+    private function resolveAllowedCountries(string $factoryName): array
+    {
+        $underscorePos = strpos($factoryName, '_');
+        if ($underscorePos === false) {
+            return [];
+        }
+
+        $account = $this->clientFactory->create($factoryName)->getAccount();
+        $pmKey = substr($factoryName, $underscorePos + 1);
+        $paymentMethods = $account['payment_methods'] ?? [];
+        Assert::isArray($paymentMethods);
+        $pmData = $paymentMethods[$pmKey] ?? [];
+        Assert::isArray($pmData);
+
+        $allowedCountries = $pmData['allowed_countries'] ?? [];
+        Assert::isArray($allowedCountries);
+
+        if (\in_array('ALL', $allowedCountries, true)) {
+            return [];
+        }
+
+        return $allowedCountries;
     }
 }

--- a/src/Resolver/AmericanExpressPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/AmericanExpressPaymentMethodsResolverDecorator.php
@@ -6,6 +6,7 @@ namespace PayPlug\SyliusPayPlugPlugin\Resolver;
 
 use PayPlug\SyliusPayPlugPlugin\Gateway\AmericanExpressGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
@@ -28,10 +29,15 @@ final class AmericanExpressPaymentMethodsResolverDecorator implements PaymentMet
         Assert::isInstanceOf($subject, Payment::class);
         $supportedMethods = $this->decorated->getSupportedMethods($subject);
 
+        /** @var OrderInterface $order */
+        $order = $subject->getOrder();
+        $billingCountryCode = $order->getBillingAddress()?->getCountryCode();
+
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             AmericanExpressGatewayFactory::FACTORY_NAME,
             $subject->getAmount() ?? 0,
+            $billingCountryCode,
         );
     }
 

--- a/src/Resolver/ApplePayPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/ApplePayPaymentMethodsResolverDecorator.php
@@ -6,6 +6,7 @@ namespace PayPlug\SyliusPayPlugPlugin\Resolver;
 
 use PayPlug\SyliusPayPlugPlugin\Gateway\ApplePayGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
@@ -28,10 +29,15 @@ final class ApplePayPaymentMethodsResolverDecorator implements PaymentMethodsRes
         Assert::isInstanceOf($subject, Payment::class);
         $supportedMethods = $this->decorated->getSupportedMethods($subject);
 
+        /** @var OrderInterface $order */
+        $order = $subject->getOrder();
+        $billingCountryCode = $order->getBillingAddress()?->getCountryCode();
+
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             ApplePayGatewayFactory::FACTORY_NAME,
             $subject->getAmount() ?? 0,
+            $billingCountryCode,
         );
     }
 

--- a/src/Resolver/BancontactPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/BancontactPaymentMethodsResolverDecorator.php
@@ -6,6 +6,7 @@ namespace PayPlug\SyliusPayPlugPlugin\Resolver;
 
 use PayPlug\SyliusPayPlugPlugin\Gateway\BancontactGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
@@ -28,10 +29,15 @@ final class BancontactPaymentMethodsResolverDecorator implements PaymentMethodsR
         Assert::isInstanceOf($subject, Payment::class);
         $supportedMethods = $this->decorated->getSupportedMethods($subject);
 
+        /** @var OrderInterface $order */
+        $order = $subject->getOrder();
+        $billingCountryCode = $order->getBillingAddress()?->getCountryCode();
+
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             BancontactGatewayFactory::FACTORY_NAME,
             $subject->getAmount() ?? 0,
+            $billingCountryCode,
         );
     }
 

--- a/src/Resolver/PayPlugPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/PayPlugPaymentMethodsResolverDecorator.php
@@ -6,6 +6,7 @@ namespace PayPlug\SyliusPayPlugPlugin\Resolver;
 
 use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
@@ -28,10 +29,15 @@ final class PayPlugPaymentMethodsResolverDecorator implements PaymentMethodsReso
         Assert::isInstanceOf($subject, Payment::class);
         $supportedMethods = $this->decorated->getSupportedMethods($subject);
 
+        /** @var OrderInterface $order */
+        $order = $subject->getOrder();
+        $billingCountryCode = $order->getBillingAddress()?->getCountryCode();
+
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             PayPlugGatewayFactory::FACTORY_NAME,
             $subject->getAmount() ?? 0,
+            $billingCountryCode,
         );
     }
 

--- a/src/Resolver/ScalapayPaymentMethodsResolverDecorator.php
+++ b/src/Resolver/ScalapayPaymentMethodsResolverDecorator.php
@@ -6,6 +6,7 @@ namespace PayPlug\SyliusPayPlugPlugin\Resolver;
 
 use PayPlug\SyliusPayPlugPlugin\Gateway\ScalapayGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Provider\SupportedMethodsProvider;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Payment;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
@@ -28,10 +29,15 @@ final class ScalapayPaymentMethodsResolverDecorator implements PaymentMethodsRes
         Assert::isInstanceOf($subject, Payment::class);
         $supportedMethods = $this->decorated->getSupportedMethods($subject);
 
+        /** @var OrderInterface $order */
+        $order = $subject->getOrder();
+        $billingCountryCode = $order->getBillingAddress()?->getCountryCode();
+
         return $this->supportedMethodsProvider->provide(
             $supportedMethods,
             ScalapayGatewayFactory::FACTORY_NAME,
             $subject->getAmount() ?? 0,
+            $billingCountryCode,
         );
     }
 

--- a/tests/PHPUnit/Provider/SupportedMethodsProviderTest.php
+++ b/tests/PHPUnit/Provider/SupportedMethodsProviderTest.php
@@ -47,7 +47,9 @@ final class SupportedMethodsProviderTest extends TestCase
     public function testProvide_withDifferentFactory_doesNotFilter(): void
     {
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
-        $this->apiClient->method('getAccount')->willReturn($this->buildAccount(30, 2000000));
+        // getAccount() must never be called: the PayPlug method never matches the Bancontact factory,
+        // so the loop always hits `continue` before reaching the lazy-loading lines.
+        $this->apiClient->expects(self::never())->method('getAccount');
 
         // PaymentMethod is PayPlug, but we're querying for Bancontact — so it's passed through as-is
         $method = $this->buildPaymentMethod(PayPlugGatewayFactory::FACTORY_NAME);
@@ -204,6 +206,82 @@ final class SupportedMethodsProviderTest extends TestCase
 
         // Bancontact is skipped (different factory), PayPlug stays
         self::assertCount(2, $result); // Bancontact not removed (no filter applied for different factory)
+    }
+
+    // -------------------------------------------------------------------------
+    // provide() — allowed_countries filter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Billing country is in the allowed_countries list → method kept.
+     */
+    public function testProvide_withAllowedCountry_keepsMethod(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $account = [
+            'configuration' => ['min_amounts' => ['EUR' => 30], 'max_amounts' => ['EUR' => 2000000]],
+            'payment_methods' => ['scalapay' => ['min_amounts' => ['EUR' => 500], 'max_amounts' => ['EUR' => 200000], 'allowed_countries' => ['FR', 'DE']]],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_scalapay');
+        $result = $this->provider->provide([$method], 'payplug_scalapay', 1000, 'FR');
+
+        self::assertCount(1, $result);
+    }
+
+    /**
+     * Billing country is NOT in the allowed_countries list → method removed.
+     */
+    public function testProvide_withDisallowedCountry_removesMethod(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $account = [
+            'configuration' => ['min_amounts' => ['EUR' => 30], 'max_amounts' => ['EUR' => 2000000]],
+            'payment_methods' => ['scalapay' => ['min_amounts' => ['EUR' => 500], 'max_amounts' => ['EUR' => 200000], 'allowed_countries' => ['FR', 'DE']]],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_scalapay');
+        $result = $this->provider->provide([$method], 'payplug_scalapay', 1000, 'US');
+
+        self::assertEmpty($result);
+    }
+
+    /**
+     * allowed_countries = ["ALL"] → country check skipped, method kept.
+     */
+    public function testProvide_withAllowedCountriesAll_keepsMethod(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $account = [
+            'configuration' => ['min_amounts' => ['EUR' => 30], 'max_amounts' => ['EUR' => 2000000]],
+            'payment_methods' => ['bancontact' => ['min_amounts' => ['EUR' => 30], 'max_amounts' => ['EUR' => 2000000], 'allowed_countries' => ['ALL']]],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_bancontact');
+        $result = $this->provider->provide([$method], 'payplug_bancontact', 1000, 'US');
+
+        self::assertCount(1, $result);
+    }
+
+    /**
+     * Billing country is null (no billing address yet) → country check skipped, method kept.
+     */
+    public function testProvide_withNullBillingCountry_keepsMethod(): void
+    {
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+        $account = [
+            'configuration' => ['min_amounts' => ['EUR' => 30], 'max_amounts' => ['EUR' => 2000000]],
+            'payment_methods' => ['scalapay' => ['min_amounts' => ['EUR' => 500], 'max_amounts' => ['EUR' => 200000], 'allowed_countries' => ['FR', 'DE']]],
+        ];
+        $this->apiClient->method('getAccount')->willReturn($account);
+
+        $method = $this->buildPaymentMethod('payplug_scalapay');
+        $result = $this->provider->provide([$method], 'payplug_scalapay', 1000, null);
+
+        self::assertCount(1, $result);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Description
<!-- Provide a clear summary of the changes and the problem it solves. -->
<!-- Include any relevant context or background information. -->

**Motivation:**
- Recovering Allowed_countries list for each APM from the API
- Use it to display or not the right APMs on the checkout page

**Related issue(s):** Closes #3365

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- [x] ✨ New feature (non-breaking change that adds functionality)

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate
