### PR TITLE
PRE-3442: Fix Oauth when acc is unboarded and redirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,10 @@
         "public-dir": "vendor/sylius/test-application/public",
         "symfony": {
             "require": "^6.4"
+        },
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
         }
     }
 }

--- a/config/twig_hooks/admin.yaml
+++ b/config/twig_hooks/admin.yaml
@@ -1,5 +1,13 @@
 sylius_twig_hooks:
     hooks:
+        'sylius_admin.payment_method.create.content.header.title_block.actions':
+            cancel:
+                template: '@PayPlugSyliusPayPlugPlugin/admin/payment_method/actions/cancel.html.twig'
+                priority: 100
+        'sylius_admin.payment_method.update.content.header.title_block.actions':
+            cancel:
+                template: '@PayPlugSyliusPayPlugPlugin/admin/payment_method/actions/cancel.html.twig'
+                priority: 100
         sylius_admin.payment_method.update.content:
             payplug_flashes:
                 template: '@PayPlugSyliusPayPlugPlugin/admin/shared/flashes.html.twig'

--- a/src/Action/Admin/Auth/UnifiedAuthenticationController.php
+++ b/src/Action/Admin/Auth/UnifiedAuthenticationController.php
@@ -111,8 +111,8 @@ final class UnifiedAuthenticationController extends AbstractController
             $liveClientDataResult = Authentication::createClientIdAndSecret($companyId, $clientName, 'live');
 
             $config = $gatewayConfig->getConfig();
-            $config['live_client'] = $liveClientDataResult['httpResponse'];
-            $config['test_client'] = $testClientDataResult['httpResponse'];
+            $config['live_client'] = $liveClientDataResult['httpResponse'] ?? null;
+            $config['test_client'] = $testClientDataResult['httpResponse'] ?? null;
             $gatewayConfig->setConfig($config);
 
             $this->entityManager->flush();

--- a/src/Controller/CompleteInfoController.php
+++ b/src/Controller/CompleteInfoController.php
@@ -14,6 +14,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -91,6 +92,7 @@ final class CompleteInfoController extends AbstractController
 
         $formBuilder = $this->createFormBuilder($completeInfo);
         foreach ($fields as $field => $type) {
+            /** @var class-string<FormTypeInterface> $type */
             $formBuilder->add($field, $type, ['required' => true, 'constraints' => [new NotBlank()]]);
         }
 

--- a/src/Gateway/Validator/Constraints/IsCanSavePaymentMethodValidator.php
+++ b/src/Gateway/Validator/Constraints/IsCanSavePaymentMethodValidator.php
@@ -46,27 +46,27 @@ final class IsCanSavePaymentMethodValidator extends ConstraintValidator
 
         Assert::stringNotEmpty($factoryName);
 
-        if (in_array($factoryName, self::GATEWAYS_SKIP, true)) {
-            return;
-        }
-
         try {
             $checker = new CanSavePayplugPaymentMethodChecker($this->apiClientFactory->createForPaymentMethod($value));
-            if (!$checker->isLive()) {
-                $this->context->buildViolation(sprintf($constraint->noTestKeyMessage, $factoryName))->addViolation();
 
+            if (in_array($factoryName, self::GATEWAYS_SKIP, true)) {
                 return;
             }
 
             if (!$checker->isEnabled($factoryName, $channels)) {
                 $this->context->buildViolation(sprintf($constraint->noAccessMessage, $factoryName))->addViolation();
+
+                return;
             }
 
-            return;
-        } catch (GatewayConfigurationException $exception) {
-            $this->context->buildViolation($exception->getMessage())
-                ->addViolation();
-        } catch (UnauthorizedException | \LogicException) {
+            if (!$checker->isLive()) {
+                $this->context->buildViolation(sprintf($constraint->noTestKeyMessage, $factoryName))->addViolation();
+
+                return;
+            }
+        } catch (GatewayConfigurationException | UnauthorizedException) {
+            $this->context->buildViolation(sprintf($constraint->noAccessMessage, $factoryName))->addViolation();
+        } catch (\LogicException) {
             return;
         }
     }

--- a/src/Gateway/Validator/Constraints/IsOneyEnabledValidator.php
+++ b/src/Gateway/Validator/Constraints/IsOneyEnabledValidator.php
@@ -57,10 +57,8 @@ final class IsOneyEnabledValidator extends ConstraintValidator
                 $this->context->buildViolation($constraint->message)
                     ->addViolation();
             }
-        } catch (UnauthorizedException) {
-            return;
-        } catch (GatewayConfigurationException $exception) {
-            $this->context->buildViolation($exception->getMessage())
+        } catch (GatewayConfigurationException | UnauthorizedException) {
+            $this->context->buildViolation($constraint->message)
                 ->addViolation();
         }
     }

--- a/templates/admin/payment_method/actions/cancel.html.twig
+++ b/templates/admin/payment_method/actions/cancel.html.twig
@@ -1,0 +1,7 @@
+{% import '@SyliusAdmin/shared/helper/button.html.twig' as button %}
+
+{{ button.default({
+    url: path('sylius_admin_payment_method_index'),
+    text: 'sylius.ui.back'|trans,
+    class: 'btn',
+}) }}

--- a/translations/validators.en.yml
+++ b/translations/validators.en.yml
@@ -59,3 +59,7 @@ payplug_sylius_payplug_plugin:
             To activate American Express, please fill in
             <a href="https://support.payplug.com/hc/en-gb/requests/new?ticket_form_id=6331992459420" target="_blank">this form</a>
             and activate the LIVE mode.
+    payplug:
+        can_not_save_method_no_access: |
+            You do not have access to LIVE mode.
+            To enable it, please complete your onboarding and reconnect.

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -58,3 +58,7 @@ payplug_sylius_payplug_plugin:
             Pour activer American Express, rendez-vous sur
             <a href="https://support.payplug.com/hc/fr/requests/new?ticket_form_id=6331992459420" target="_blank">ce formulaire</a>
             et activez le mode LIVE.
+    payplug:
+        can_not_save_method_no_access: |
+            Vous n'avez pas accès au mode LIVE.
+            Pour l'activer, veuillez terminer votre onboarding et vous reconnecter.

--- a/translations/validators.it.yml
+++ b/translations/validators.it.yml
@@ -58,3 +58,7 @@ payplug_sylius_payplug_plugin:
             Per attivare American Express, compila
             <a href="https://support.payplug.com/hc/it/requests/new?ticket_form_id=6331992459420" target="_blank">questo modulo</a>
             e attiva la modalità LIVE.
+    payplug:
+        can_not_save_method_no_access: |
+            Non hai accesso alla modalità LIVE.
+            Per attivarla, completa il tuo onboarding e riconnettiti.


### PR DESCRIPTION
## Description
PRE-3442: Fix Oauth when acc is unboarded and redirect

**Motivation:**
- Fix redirect after Oauth login : When the "Back" button was clicked, we were redirected to the Portal instead of the list of payment methods
- Fix the Oauth login when an account isn't onboarded : the payment mehod is deactivated and it shows an error message 

**Related issue(s):** Closes # [PRE-3442](https://payplug-prod.atlassian.net/jira/software/c/projects/PRE/boards/50?selectedIssue=PRE-3442)

---

## Type of Change
<!-- check the corresponding checkbox(es) with an "x" -->
- 🐛 Bug fix (non-breaking change that fixes an issue) [x]
- ✨ New feature (non-breaking change that adds functionality) [ ]
- 💥 Breaking change (fix or feature that causes existing functionality to change and that could impact other libs) [ ]
- 🔧 Refactor (no functional changes, code improvement only) [ ]
- 📦 Dependency update [ ]
- 🔒 Security fix [ ]
- 📝 Documentation update [ ]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate


[PRE-3442]: https://payplug-prod.atlassian.net/browse/PRE-3442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ