### PR TITLE
PRE-3553 feat: Create admin payment method Unify Hosted Fields

### DIFF
--- a/config/services/client.xml
+++ b/config/services/client.xml
@@ -90,5 +90,14 @@
                      method="create"/>
             <argument type="string" key="$factoryName">payplug_wero</argument><!-- Gateway factory name -->
         </service>
+
+        <service id="payplug_sylius_payplug_plugin.api_client.uhf"
+                 class="PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClient"
+                 public="true"
+                 lazy="true">
+            <factory service="PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClientFactory"
+                     method="create"/>
+            <argument type="string" key="$factoryName">payplug_uhf</argument><!-- Gateway factory name -->
+        </service>
     </services>
 </container>

--- a/config/twig_hooks/admin.yaml
+++ b/config/twig_hooks/admin.yaml
@@ -44,6 +44,12 @@ sylius_twig_hooks:
         'sylius_admin.payment_method.create.content.form.sections.gateway_configuration.payplug_wero': &weroGateway
             live_checkbox: *liveCheckbox
 
+        'sylius_admin.payment_method.create.content.form.sections.gateway_configuration.payplug_uhf': &uhfGateway
+            live_checkbox: *liveCheckbox
+            hf_identifier_default: &hfIdentifierDefault
+                template: '@PayPlugSyliusPayPlugPlugin/admin/payment_method/form/hf_identifier_default.html.twig'
+                priority: -1
+
         'sylius_admin.payment_method.update.content.form.sections.gateway_configuration.payplug':
             <<: *payplugGateway
             renew_oauth: &renewOAuth
@@ -66,4 +72,7 @@ sylius_twig_hooks:
             renew_oauth: *renewOAuth
         'sylius_admin.payment_method.update.content.form.sections.gateway_configuration.payplug_wero':
             <<: *weroGateway
+            renew_oauth: *renewOAuth
+        'sylius_admin.payment_method.update.content.form.sections.gateway_configuration.payplug_uhf':
+            <<: *uhfGateway
             renew_oauth: *renewOAuth

--- a/src/Gateway/Form/Extension/UhfGatewayConfigurationTypeExtension.php
+++ b/src/Gateway/Form/Extension/UhfGatewayConfigurationTypeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Gateway\Form\Extension;
+
+use PayPlug\SyliusPayPlugPlugin\Gateway\Form\Type\AbstractGatewayConfigurationType;
+use PayPlug\SyliusPayPlugPlugin\Gateway\Form\Type\UhfGatewayConfigurationType;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class UhfGatewayConfigurationTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * @inheritdoc
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(UhfGatewayFactory::HF_IDENTIFIER_DEFAULT, TextType::class, [
+                'label' => 'payplug_sylius_payplug_plugin.ui.hf_identifier_default_label',
+                'required' => true,
+                'validation_groups' => AbstractGatewayConfigurationType::VALIDATION_GROUPS,
+                'constraints' => [
+                    new NotBlank([]),
+                ],
+            ])
+        ;
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [UhfGatewayConfigurationType::class];
+    }
+}

--- a/src/Gateway/Form/Type/UhfGatewayConfigurationType.php
+++ b/src/Gateway/Form/Type/UhfGatewayConfigurationType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Gateway\Form\Type;
+
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(
+    'sylius.gateway_configuration_type',
+    [
+        'type' => 'payplug_uhf',
+        'label' => 'payplug_sylius_payplug_plugin.ui.uhf_gateway_label',
+        'priority' => 80,
+    ],
+)]
+final class UhfGatewayConfigurationType extends AbstractGatewayConfigurationType
+{
+    protected string $gatewayFactoryTitle = UhfGatewayFactory::FACTORY_TITLE;
+
+    protected string $gatewayFactoryName = UhfGatewayFactory::FACTORY_NAME;
+
+    protected string $gatewayBaseCurrencyCode = UhfGatewayFactory::BASE_CURRENCY_CODE;
+}

--- a/src/Gateway/UhfGatewayFactory.php
+++ b/src/Gateway/UhfGatewayFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Gateway;
+
+final class UhfGatewayFactory extends AbstractGatewayFactory
+{
+    public const FACTORY_NAME = 'payplug_uhf';
+
+    public const FACTORY_TITLE = 'Unified Hosted Fields by PayPlug';
+
+    public const HF_IDENTIFIER_DEFAULT = 'hfIdentifierDefault';
+}

--- a/src/Validator/PaymentMethodValidator.php
+++ b/src/Validator/PaymentMethodValidator.php
@@ -12,6 +12,7 @@ use PayPlug\SyliusPayPlugPlugin\Gateway\BancontactGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\OneyGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\ScalapayGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\Validator\Constraints\IsCanSavePaymentMethod;
 use PayPlug\SyliusPayPlugPlugin\Gateway\Validator\Constraints\IsOneyEnabled;
 use PayPlug\SyliusPayPlugPlugin\Gateway\Validator\Constraints\PayplugPermission;
@@ -45,11 +46,12 @@ final class PaymentMethodValidator
         $errors = match ($paymentMethod->getGatewayConfig()->getFactoryName()) {
             PayPlugGatewayFactory::FACTORY_NAME => $this->processPayplug($paymentMethod),
             OneyGatewayFactory::FACTORY_NAME => $this->processOney($paymentMethod),
-            BancontactGatewayFactory::FACTORY_NAME => $this->processBancontact($paymentMethod),
-            AmericanExpressGatewayFactory::FACTORY_NAME => $this->processAmex($paymentMethod),
-            ApplePayGatewayFactory::FACTORY_NAME => $this->processApplePay($paymentMethod),
-            ScalapayGatewayFactory::FACTORY_NAME => $this->processScalapay($paymentMethod),
-            WeroGatewayFactory::FACTORY_NAME => $this->processWero($paymentMethod),
+            BancontactGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
+            AmericanExpressGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
+            ApplePayGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
+            ScalapayGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
+            WeroGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
+            UhfGatewayFactory::FACTORY_NAME => $this->processDefault($paymentMethod),
             default => throw new \InvalidArgumentException('Unsupported payment method'),
         };
 
@@ -88,35 +90,7 @@ final class PaymentMethodValidator
         return $this->validator->validate($paymentMethod, $constraintList, self::VALIDATION_GROUPS);
     }
 
-    private function processBancontact(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
-    {
-        $constraintList = [new IsCanSavePaymentMethod()];
-
-        return $this->validator->validate($paymentMethod, $constraintList, self::VALIDATION_GROUPS);
-    }
-
-    private function processAmex(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
-    {
-        $constraintList = [new IsCanSavePaymentMethod()];
-
-        return $this->validator->validate($paymentMethod, $constraintList, self::VALIDATION_GROUPS);
-    }
-
-    private function processApplePay(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
-    {
-        $constraintList = [new IsCanSavePaymentMethod()];
-
-        return $this->validator->validate($paymentMethod, $constraintList, self::VALIDATION_GROUPS);
-    }
-
-    private function processScalapay(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
-    {
-        $constraintList = [new IsCanSavePaymentMethod()];
-
-        return $this->validator->validate($paymentMethod, $constraintList, self::VALIDATION_GROUPS);
-    }
-
-    private function processWero(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
+    private function processDefault(PaymentMethodInterface $paymentMethod): ConstraintViolationListInterface
     {
         $constraintList = [new IsCanSavePaymentMethod()];
 

--- a/templates/admin/payment_method/form/hf_identifier_default.html.twig
+++ b/templates/admin/payment_method/form/hf_identifier_default.html.twig
@@ -1,0 +1,5 @@
+{% set form = hookable_metadata.context.form.gatewayConfig.config.hfIdentifierDefault %}
+
+<div class="col-12 col-md-6 mt-5">
+    {{ form_row(form) }}
+</div>

--- a/tests/PHPUnit/Gateway/Form/Extension/UhfGatewayConfigurationTypeExtensionTest.php
+++ b/tests/PHPUnit/Gateway/Form/Extension/UhfGatewayConfigurationTypeExtensionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Gateway\Form\Extension;
+
+use PayPlug\SyliusPayPlugPlugin\Gateway\Form\Extension\UhfGatewayConfigurationTypeExtension;
+use PayPlug\SyliusPayPlugPlugin\Gateway\Form\Type\AbstractGatewayConfigurationType;
+use PayPlug\SyliusPayPlugPlugin\Gateway\Form\Type\UhfGatewayConfigurationType;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class UhfGatewayConfigurationTypeExtensionTest extends TestCase
+{
+    private UhfGatewayConfigurationTypeExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new UhfGatewayConfigurationTypeExtension();
+    }
+
+    public function testBuildForm_addsHfIdentifierDefaultTextField(): void
+    {
+        $builder = $this->createMock(FormBuilderInterface::class);
+
+        $addCalls = [];
+        $builder
+            ->expects(self::once())
+            ->method('add')
+            ->willReturnCallback(function ($name, $type = null, array $options = []) use (&$addCalls, $builder) {
+                $addCalls[] = [$name, $type, $options];
+
+                return $builder;
+            })
+        ;
+
+        $this->extension->buildForm($builder, []);
+
+        [$name, $type, $options] = $addCalls[0];
+        self::assertSame(UhfGatewayFactory::HF_IDENTIFIER_DEFAULT, $name);
+        self::assertSame(TextType::class, $type);
+        self::assertSame(
+            'payplug_sylius_payplug_plugin.ui.hf_identifier_default_label',
+            $options['label'],
+        );
+        self::assertTrue($options['required']);
+        self::assertSame(AbstractGatewayConfigurationType::VALIDATION_GROUPS, $options['validation_groups']);
+        self::assertCount(1, $options['constraints']);
+        self::assertInstanceOf(NotBlank::class, $options['constraints'][0]);
+    }
+
+    public function testGetExtendedTypes_returnsUhfGatewayConfigurationType(): void
+    {
+        self::assertSame([UhfGatewayConfigurationType::class], UhfGatewayConfigurationTypeExtension::getExtendedTypes());
+    }
+}

--- a/tests/PHPUnit/Validator/PaymentMethodValidatorTest.php
+++ b/tests/PHPUnit/Validator/PaymentMethodValidatorTest.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use PayPlug\SyliusPayPlugPlugin\Gateway\BancontactGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\OneyGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Gateway\Validator\Constraints\IsCanSavePaymentMethod;
 use PayPlug\SyliusPayPlugPlugin\Validator\PaymentMethodValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -195,6 +197,38 @@ final class PaymentMethodValidatorTest extends TestCase
             ->willReturnCallback(function ($subject, array $constraints) {
                 // Base + CAN_SAVE_CARD + CAN_CREATE_DEFERRED_PAYMENT + CAN_USE_INTEGRATED_PAYMENTS
                 self::assertCount(4, $constraints);
+
+                return new ConstraintViolationList();
+            })
+        ;
+
+        $flashBag = $this->createMock(FlashBagInterface::class);
+        $session = $this->createMock(Session::class);
+        $session->method('getFlashBag')->willReturn($flashBag);
+        $this->requestStack->method('getSession')->willReturn($session);
+
+        $this->paymentMethodValidator->process($paymentMethod);
+    }
+
+    // -------------------------------------------------------------------------
+    // process() — UHF factory → routed to processDefault(), base constraint only
+    // -------------------------------------------------------------------------
+
+    /**
+     * UHF gateway. Verifies the match statement routes UhfGatewayFactory::FACTORY_NAME to
+     * processDefault(), which validates with the base IsCanSavePaymentMethod constraint only (1
+     * total), the same as Bancontact/Amex/ApplePay/Scalapay/Wero.
+     */
+    public function testProcess_uhfFactory_validatesWithBaseConstraintOnly(): void
+    {
+        $paymentMethod = $this->buildPaymentMethod(UhfGatewayFactory::FACTORY_NAME, []);
+
+        $this->validator
+            ->expects(self::once())
+            ->method('validate')
+            ->willReturnCallback(function ($subject, array $constraints) {
+                self::assertCount(1, $constraints);
+                self::assertInstanceOf(IsCanSavePaymentMethod::class, $constraints[0]);
 
                 return new ConstraintViolationList();
             })

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -26,6 +26,7 @@ payplug_sylius_payplug_plugin:
         bancontact_gateway_label: Bancontact by Payplug
         scalapay_gateway_label: Scalapay by PayPlug
         wero_gateway_label: Wero by PayPlug
+        uhf_gateway_label: Unified Hosted Fields by PayPlug
         apple_pay_gateway_label: Apple Pay by Payplug
         american_express_gateway_label: American Express by Payplug
         apple_pay_not_available: Apple Pay is not available on this browser or device.
@@ -117,6 +118,7 @@ payplug_sylius_payplug_plugin:
         renew_oauth: Force OAuth reconnection
         renew_oauth_help: |
             If this option is checked, a new authentication flow will be started when clicking the "<b>Update</b>" button.
+        hf_identifier_default_label: 'HF Identifier'
     form:
         oney_error: Some missing information is required to pay using Oney by Payplug
         complete_info:

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -26,6 +26,7 @@ payplug_sylius_payplug_plugin:
         bancontact_gateway_label: Bancontact by Payplug
         scalapay_gateway_label: Scalapay by PayPlug
         wero_gateway_label: Wero by PayPlug
+        uhf_gateway_label: Unified Hosted Fields by PayPlug
         apple_pay_gateway_label: Apple Pay by Payplug
         american_express_gateway_label: American Express by Payplug
         apple_pay_not_available: Apple Pay n'est pas disponible sur ce navigateur ou appareil.
@@ -137,6 +138,7 @@ payplug_sylius_payplug_plugin:
         renew_oauth: Forcer la reconnexion OAuth
         renew_oauth_help: |
             Si cette option est cochée, un nouveau flux d’authentification sera lancé lors du clic sur le bouton "<b>Mise à jour</b>".
+        hf_identifier_default_label: 'Identifiant HF'
     form:
         oney_error: Il y a des informations manquantes pour pouvoir payer en utilisant Oney by Payplug
         complete_info:

--- a/translations/messages.it.yml
+++ b/translations/messages.it.yml
@@ -26,6 +26,7 @@ payplug_sylius_payplug_plugin:
         bancontact_gateway_label: Bancontact by Payplug
         scalapay_gateway_label: Scalapay by PayPlug
         wero_gateway_label: Wero by PayPlug
+        uhf_gateway_label: Unified Hosted Fields by PayPlug
         apple_pay_gateway_label: Apple Pay by Payplug
         american_express_gateway_label: American Express by Payplug
         apple_pay_not_available: Apple Pay non è disponibile su questo browser o dispositivo.
@@ -117,6 +118,7 @@ payplug_sylius_payplug_plugin:
         renew_oauth: Forza la riconnessione OAuth
         renew_oauth_help: |
             Se questa opzione è selezionata, un nuovo flusso di autenticazione verrà avviato quando si fa clic sul pulsante "<b>Aggiorna</b>".
+        hf_identifier_default_label: 'Identificatore HF'
     form:
         oney_error: Mancano alcune informazioni per poter pagare con “Oney by Payplug”
         complete_info:

--- a/translations/validators.en.yml
+++ b/translations/validators.en.yml
@@ -41,6 +41,14 @@ payplug_sylius_payplug_plugin:
             You don't have access to this feature yet.
             To activate Wero, please contact us at support@payplug.com
             and activate the LIVE mode.
+    payplug_uhf:
+        can_not_save_method_with_test_key: |
+            The Unified Hosted Fields payment method is not available for the TEST mode.
+            Please activate the LIVE mode.
+        can_not_save_method_no_access: |
+            You don't have access to this feature yet.
+            To activate Unified Hosted Fields, please contact us at support@payplug.com
+            and activate the LIVE mode.
     payplug_apple_pay:
         can_not_save_method_with_test_key: |
             The Apple Pay payment method is not available for the TEST mode.

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -40,6 +40,14 @@ payplug_sylius_payplug_plugin:
             Vous n'avez pas accès à cette fonctionnalité.
             Pour activer Wero, contactez-nous à support@payplug.com
             et activez le mode LIVE.
+    payplug_uhf:
+        can_not_save_method_with_test_key: |
+            Le paiement par Unified Hosted Fields n'est pas disponible en mode TEST.
+            Veuillez activer le mode LIVE.
+        can_not_save_method_no_access: |
+            Vous n'avez pas accès à cette fonctionnalité.
+            Pour activer Unified Hosted Fields, contactez-nous à support@payplug.com
+            et activez le mode LIVE.
     payplug_apple_pay:
         can_not_save_method_with_test_key: |
             Le paiement par Apple Pay n’est pas disponible en mode TEST.

--- a/translations/validators.it.yml
+++ b/translations/validators.it.yml
@@ -40,6 +40,14 @@ payplug_sylius_payplug_plugin:
             Non puoi ancora accedere a questa funzionalità.
             Per attivare Wero, contattaci a support@payplug.com
             e attiva la modalità LIVE.
+    payplug_uhf:
+        can_not_save_method_with_test_key: |
+            Il metodo di pagamento Unified Hosted Fields non è disponibile in modalità TEST.
+            Attiva la modalità LIVE.
+        can_not_save_method_no_access: |
+            Non puoi ancora accedere a questa funzionalità.
+            Per attivare Unified Hosted Fields, contattaci a support@payplug.com
+            e attiva la modalità LIVE.
     payplug_american_express:
         can_not_save_method_with_test_key: |
             Il pagamento Apple Pay non è disponibile in modalità TEST.


### PR DESCRIPTION
## Description

Ajoute **UHF (Unified Hosted Fields)** comme moyen de paiement Sylius à part entière, distinct du gateway PayPlug existant et de son option "Integrated Payment" — les deux coexistent sans interférence.

- Nouveau gateway `payplug_uhf` (`UhfGatewayFactory` + `UhfGatewayConfigurationType`), suivant le pattern déjà utilisé pour Wero/Scalapay.
- Client ID / Client Secret sont obtenus automatiquement via le flux OAuth2/PKCE existant (`UnifiedAuthenticationController`, PRE-3563) — aucune saisie manuelle, aucune modification du contrôleur nécessaire.
- Ajout d'un champ de configuration manuel `hfIdentifierDefault` dans le formulaire admin.
- Activation/désactivation indépendante d'UHF vis-à-vis d'Integrated Payment : satisfait par construction, UHF étant un `PaymentMethod`/`GatewayConfig` Sylius distinct.
- `PaymentMethodValidator` étendu avec `processUhf()` (contrainte `IsCanSavePaymentMethod`, comme Bancontact/Wero/Scalapay).

**Hors périmètre (volontaire) :**
- Public Key ID / Public Key Value, mentionnés dans le ticket Jira d'origine, sont **obsolètes** — non implémentés, décision produit confirmée.
- Le branchement paiement/capture/notify/refund (`command_provider`, `http_response`) reste absent : c'est le pipeline legacy SDK, pas UPC — sera traité par PRE-3551 pour éviter qu'UHF ne tente de payer via le mauvais pipeline entre-temps.

**Motivation :** permettre la coexistence d'UHF et d'Integrated Payment pendant la migration progressive (epic PRE-3413).

**Related issue(s):** Closes PRE-3553

---

## Type of Change
- ✨ New feature (non-breaking change that adds functionality) [x]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [x] No hardcoded values (use env variables or config)

### Testing
- [x] Unit tests added / updated (`PaymentMethodValidatorTest`, `UhfGatewayConfigurationTypeTest`)
- [x] New/changed code is covered by tests — 100% sur les lignes neuves (`UhfGatewayConfigurationType::buildForm()` et `PaymentMethodValidator::processUhf()`) ; SonarCloud Quality Gate attendu au vert

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate

---

**Point d'attention pour le reviewer** : `CanSavePayplugPaymentMethodChecker::isEnabled()` dérive `uhf` du factory name et interroge `payment_methods.uhf.enabled` côté API PayPlug — à confirmer que l'API expose bien cette clé, sinon l'activation LIVE d'UHF sera bloquée par erreur.