### PR TITLE
PRE-3551: create payment with Hosted Fields

### DIFF
--- a/assets/shop/controllers/hosted-fields_controller.js
+++ b/assets/shop/controllers/hosted-fields_controller.js
@@ -113,12 +113,13 @@ export default class extends Controller {
     this.hfields = window.dalenys.hostedFields({
       companyId: payplug_hosted_fields_params.companyId,
       fields: {
-        brand: { id: 'brand-container', style: FIELD_STYLE },
-        card: { id: 'card-container', style: FIELD_STYLE },
-        expiry: { id: 'expiry-container', style: FIELD_STYLE },
-        cryptogram: { id: 'cvv-container', style: FIELD_STYLE },
+        brand:       { id: "brand-container", version: 2, style: FIELD_STYLE },
+        card:        { id: "card-container", placeholder: "•••• •••• •••• ••••", enableAutospacing: true, style: FIELD_STYLE },
+        expiry:      { id: "expiry-container", placeholder: "MM/AA", style: FIELD_STYLE },
+        cryptogram:  { id: "cvv-container", placeholder: "CVV", style: FIELD_STYLE },
       },
-      location: payplug_hosted_fields_params.locale,
+
+      locale: payplug_hosted_fields_params.locale,
     });
     this.hfields.load();
   }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "giggsey/libphonenumber-for-php": "^8.12",
         "payplug/payplug-php": "^4.0",
-        "payplug/unified-plugin-core": "0.0.7",
+        "payplug/unified-plugin-core": "1.0.0-rc0",
         "php-http/message-factory": "^1.1",
         "sylius/refund-plugin": "^2.0",
         "sylius/sylius": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "giggsey/libphonenumber-for-php": "^8.12",
         "payplug/payplug-php": "^4.0",
-        "payplug/unified-plugin-core": "1.0.0-rc0",
+        "payplug/unified-plugin-core": "1.0.0-rc1",
         "php-http/message-factory": "^1.1",
         "sylius/refund-plugin": "^2.0",
         "sylius/sylius": "^2.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,6 +5,15 @@ parameters:
     payplug.oauth_base_url: '%env(default:payplug.oauth_base_url.default:PAYPLUG_OAUTH_BASE_URL)%'
     payplug.oauth_audience.default: 'https://www.payplug.com'
     payplug.oauth_audience: '%env(default:payplug.oauth_audience.default:PAYPLUG_OAUTH_AUDIENCE)%'
+    payplug.unified_api_base_url.default: 'https://api.payplug.com'
+    payplug.unified_api_base_url: '%env(default:payplug.unified_api_base_url.default:PAYPLUG_UNIFIED_API_BASE_URL)%'
+    # TEMPORARY (PRE-3551 QA testing): the Unified API account id is hardcoded here rather than
+    # resolved dynamically. This will be reworked once the real per-merchant account resolution
+    # for UHF is implemented — do not treat this as the final design.
+    payplug.uhf_account_id.default: 'PAYPLUG_PF QA'
+    payplug.uhf_account_id: '%env(default:payplug.uhf_account_id.default:PAYPLUG_UHF_ACCOUNT_ID)%'
+    payplug.uhf_submerchant_external_id.default: '48Su3ZqMlLKmqrg'
+    payplug.uhf_submerchant_external_id: '%env(default:payplug.uhf_submerchant_external_id.default:PAYPLUG_UHF_SUBMERCHANT_EXTERNAL_ID)%'
 
 services:
     _defaults:
@@ -19,6 +28,9 @@ services:
             Psr\Log\LoggerInterface: '@monolog.logger.payplug'
             $payplugOauthBaseUrl: '%payplug.oauth_base_url%'
             $payplugOauthAudience: '%payplug.oauth_audience%'
+            $unifiedApiBaseUrl: '%payplug.unified_api_base_url%'
+            $uhfAccountId: '%payplug.uhf_account_id%'
+            $uhfSubmerchantExternalId: '%payplug.uhf_submerchant_external_id%'
 
     PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepositoryInterface:
         class: PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepository
@@ -39,6 +51,27 @@ services:
     # `PayPlug\SyliusPayPlugPlugin\:` prototype above, keeping its `@monolog.logger.payplug` binding.
     PayPlug\SyliusPayPlugPlugin\PaymentProcessing\HostedFieldsPaymentProcessorInterface:
         alias: PayPlug\SyliusPayPlugPlugin\PaymentProcessing\NullHostedFieldsPaymentProcessor
+
+    PayplugUnifiedCore\Contracts\ILogger:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcLogger
+
+    PayplugUnifiedCore\Contracts\ILock:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcLock
+
+    PayplugUnifiedCore\Contracts\IUnifiedApiHttpClient:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusUnifiedApiHttpClient
+
+    PayplugUnifiedCore\Contracts\IConfigurationRepository:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcConfigurationRepository
+
+    PayplugUnifiedCore\Contracts\IPaymentRepository:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusPaymentOperationRepository
+
+    PayplugUnifiedCore\Contracts\IOrderStateMutator:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\SyliusOrderStateMutator
+
+    PayPlug\SyliusPayPlugPlugin\Upc\HostedPaymentCreatorInterface:
+        alias: PayPlug\SyliusPayPlugPlugin\Upc\UnifiedApiHostedPaymentCreator
 
     payplug_sylius_payplug_plugin.action.capture:
         class: PayPlug\SyliusPayPlugPlugin\Action\CaptureAction
@@ -194,3 +227,23 @@ services:
         tags:
             - name: sylius.payment_request.provider.http_response
               gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\ApplePayGatewayFactory::FACTORY_NAME
+
+    ## UHF Payplug Gateway ##
+    payplug_sylius_payplug_plugin.command_provider.payplug_uhf:
+        class: Sylius\Bundle\PaymentBundle\CommandProvider\ActionsCommandProvider
+        arguments:
+            - !tagged_locator
+                tag: payplug_sylius_payplug_plugin.command_provider.payplug_uhf
+                index_by: 'action'
+        tags:
+            - name: sylius.payment_request.command_provider
+              gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory::FACTORY_NAME
+    payplug_sylius_payplug_plugin.provider.order_pay.http_response.payplug_uhf:
+        class: Sylius\Bundle\PaymentBundle\Provider\ActionsHttpResponseProvider
+        arguments:
+            - !tagged_locator
+                tag: payplug_sylius_payplug_plugin.http_response_provider.payplug_uhf
+                index_by: action
+        tags:
+            - name: sylius.payment_request.provider.http_response
+              gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory::FACTORY_NAME

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,13 +7,6 @@ parameters:
     payplug.oauth_audience: '%env(default:payplug.oauth_audience.default:PAYPLUG_OAUTH_AUDIENCE)%'
     payplug.unified_api_base_url.default: 'https://api.payplug.com'
     payplug.unified_api_base_url: '%env(default:payplug.unified_api_base_url.default:PAYPLUG_UNIFIED_API_BASE_URL)%'
-    # TEMPORARY (PRE-3551 QA testing): the Unified API account id is hardcoded here rather than
-    # resolved dynamically. This will be reworked once the real per-merchant account resolution
-    # for UHF is implemented — do not treat this as the final design.
-    payplug.uhf_account_id.default: 'PAYPLUG_PF QA'
-    payplug.uhf_account_id: '%env(default:payplug.uhf_account_id.default:PAYPLUG_UHF_ACCOUNT_ID)%'
-    payplug.uhf_submerchant_external_id.default: '48Su3ZqMlLKmqrg'
-    payplug.uhf_submerchant_external_id: '%env(default:payplug.uhf_submerchant_external_id.default:PAYPLUG_UHF_SUBMERCHANT_EXTERNAL_ID)%'
 
 services:
     _defaults:
@@ -29,8 +22,6 @@ services:
             $payplugOauthBaseUrl: '%payplug.oauth_base_url%'
             $payplugOauthAudience: '%payplug.oauth_audience%'
             $unifiedApiBaseUrl: '%payplug.unified_api_base_url%'
-            $uhfAccountId: '%payplug.uhf_account_id%'
-            $uhfSubmerchantExternalId: '%payplug.uhf_submerchant_external_id%'
 
     PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepositoryInterface:
         class: PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepository
@@ -227,23 +218,3 @@ services:
         tags:
             - name: sylius.payment_request.provider.http_response
               gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\ApplePayGatewayFactory::FACTORY_NAME
-
-    ## UHF Payplug Gateway ##
-    payplug_sylius_payplug_plugin.command_provider.payplug_uhf:
-        class: Sylius\Bundle\PaymentBundle\CommandProvider\ActionsCommandProvider
-        arguments:
-            - !tagged_locator
-                tag: payplug_sylius_payplug_plugin.command_provider.payplug_uhf
-                index_by: 'action'
-        tags:
-            - name: sylius.payment_request.command_provider
-              gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory::FACTORY_NAME
-    payplug_sylius_payplug_plugin.provider.order_pay.http_response.payplug_uhf:
-        class: Sylius\Bundle\PaymentBundle\Provider\ActionsHttpResponseProvider
-        arguments:
-            - !tagged_locator
-                tag: payplug_sylius_payplug_plugin.http_response_provider.payplug_uhf
-                index_by: action
-        tags:
-            - name: sylius.payment_request.provider.http_response
-              gateway_factory: !php/const PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory::FACTORY_NAME

--- a/features/shop/hosted_fields_payment_and_webhook_flow.feature
+++ b/features/shop/hosted_fields_payment_and_webhook_flow.feature
@@ -1,0 +1,80 @@
+# PRE-3551 / Task 14 — end-to-end coverage for the payplug_uhf (Unified Hosted Fields) capture +
+# UPC webhook pipeline built by Tasks 1-13.
+#
+# IMPORTANT — read before relying on this file:
+#
+# This file is WRITTEN BUT NOT EXECUTABLE YET. Every step in the Background and in the opening
+# "Given"/"When"/"Then" lines that also appear in features/shop/hosted_fields_payment_method.feature
+# or features/shop/update_payment_state.feature is backed by a real, already-merged step
+# definition and is safe to trust. Steps marked "# NEW — not yet defined" below do not resolve to
+# any step definition in this codebase today; Behat would report them as "undefined", not pass or
+# fail. See tests-Behat/task-14-report.md (PRE-3551 SDD folder) for why, and for a sketch of the
+# infrastructure (Mocker + a raw-HTTP webhook page object + a PaymentRequest fixture step) that
+# would need to be designed and built — not guessed — before these two scenarios can actually run.
+@paying_with_payplug_for_order
+Feature: Paying with Unified Hosted Fields and receiving the UPC webhook confirmation
+    In order to buy products with a card processed through PayPlug's Unified API
+    As a Customer
+    I want my order to be confirmed once the asynchronous UPC webhook notification arrives
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And that channel also allows to shop using the "EUR" currency
+        And there is a user "john@bitbag.pl" identified by "password123"
+        And I changed my currency to "EUR"
+        And the store has a payment method "Unified Hosted Fields" with a code "payplug_uhf" and PayPlug Hosted Fields payment gateway
+        And This secret Key is valid
+        And the store ships everywhere for free
+        And the store has "DHL" shipping method with "$0.00" fee
+        And I am logged in as "john@bitbag.pl"
+        And the store has a product "PHP T-Shirt" priced at "€50.00"
+
+    @ui
+    Scenario: Paying with Unified Hosted Fields completes the order without a 3DS redirect
+        Given I added product "PHP T-Shirt" to the cart
+        And I chose "DHL" shipping method
+        Then I should be on the checkout payment step
+        And I should be able to select "Unified Hosted Fields" payment method
+        And I select "Unified Hosted Fields" payment method
+        And I should see the "#card-container" element on the page
+        # NEW — not yet defined. Needs: (1) HostedPaymentCreatorInterface made a public service
+        # (currently private by DI default) so a Behat Mocker can swap it, mirroring
+        # tests/Behat/Mocker/PayPlugApiMocker's pattern for the legacy PayPlugApiClientInterface;
+        # (2) a new UhfApiMocker::mockCreateHostedPaymentWithoutRedirect() stubbing
+        # createHostedPayment() to return a HostedPaymentOutput with redirectUrl = null.
+        And the Unified API is stubbed to accept the payment without requiring 3DS
+        # NEW — not yet defined, and not just missing a step: card entry goes through a real,
+        # cross-origin Dalenys hostedFields iframe SDK (assets/shop/controllers/hosted-fields_controller.js)
+        # loaded from PayPlug's own domain. There is no server-side seam to stub this — Behat would
+        # need either a live sandbox tokenization endpoint or a test-only shim replacing
+        # window.dalenys before the page loads. Deciding whether to build that shim is a product/
+        # architecture call, not a step-definition gap.
+        When I fill in my card details and confirm the payment
+        Then I should see the thank you page
+        # NEW — not yet defined. "Eventually" implies polling/waiting for an async webhook POST
+        # that nothing in this suite currently sends (see Scenario 2's blockers below).
+        And the order's payment should eventually be marked as paid once the webhook is delivered
+
+    @ui
+    Scenario: A retried UPC webhook notification is not processed twice
+        # NEW — not yet defined. Needs a fixture step that creates an Order + Payment already
+        # past the capture step (hosted_fields_created_at set, Payment state "processing") plus a
+        # real Sylius PaymentRequestInterface (action=notify, hash known) so the scenario has a
+        # real notify URL to POST to — sylius/sylius's PaymentRequest entity/repository isn't
+        # available in this checkout's vendor/ to confirm the exact construction API, so writing
+        # this without running it would be guessing at Sylius core internals, not this plugin's.
+        Given an order paid with "Unified Hosted Fields" is awaiting webhook confirmation
+        # NEW — not yet defined. Needs a Page object that performs a raw HTTP POST (via the Mink
+        # BrowserKit driver's underlying client) to the sylius_payment_request_notify route for
+        # that PaymentRequest's hash, with body {"id","execCode","orderId","amount"} and an
+        # Authorization header matching whatever the "payplug_webhook_authorization_header" gateway
+        # config key was seeded to in the Given step above (see
+        # src/Upc/SyliusUpcConfigurationRepository::get() and
+        # src/Command/Handler/NotifyHostedPaymentRequestHandler — confirmed by
+        # tests/PHPUnit/Command/Handler/NotifyHostedPaymentRequestHandlerTest, which is the most
+        # reliable reference for the exact payload/header shape).
+        When the UPC webhook notification is delivered
+        And the same UPC webhook notification is delivered again
+        # NEW — not yet defined. No existing step asserts Payment state (only order state, via
+        # CheckoutContext::theLatestOrderHasState) or asserts a call count on IPaymentRepository.
+        Then the order's payment should be marked as paid exactly once

--- a/migrations/Version20260810120000.php
+++ b/migrations/Version20260810120000.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260810120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Added PayPlug UPC operation entity.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE payplug_upc_operation (
+          id INT AUTO_INCREMENT NOT NULL,
+          order_id VARCHAR(255) NOT NULL,
+          operation_id VARCHAR(255) NOT NULL,
+          exec_code VARCHAR(255) NOT NULL,
+          outcome VARCHAR(255) NOT NULL,
+          amount INT NOT NULL,
+          treated TINYINT(1) NOT NULL,
+          created_at DATETIME NOT NULL,
+          UNIQUE INDEX UNIQ_payplug_upc_operation_operation_id (operation_id),
+          INDEX idx_payplug_upc_operation_order_id (order_id),
+          PRIMARY KEY(id)
+        ) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE payplug_upc_operation');
+    }
+}

--- a/src/Command/CaptureHostedPaymentRequest.php
+++ b/src/Command/CaptureHostedPaymentRequest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command;
+
+class CaptureHostedPaymentRequest extends AbstractPayplugPaymentRequest
+{
+}

--- a/src/Command/Handler/CaptureHostedPaymentRequestHandler.php
+++ b/src/Command/Handler/CaptureHostedPaymentRequestHandler.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Upc\HostedPaymentCreatorInterface;
+use PayplugUnifiedCore\Contracts\IOrderStateMutator;
+use PayplugUnifiedCore\Dto\BrowserDto;
+use PayplugUnifiedCore\Dto\CommonFieldsDto;
+use PayplugUnifiedCore\Dto\CustomerDto;
+use PayplugUnifiedCore\Dto\HostedFieldDto;
+use PayplugUnifiedCore\Exceptions\ApiException;
+use PayplugUnifiedCore\Exceptions\InvalidHostedFieldException;
+use PayplugUnifiedCore\Utilities\Helpers\ExecCodeMapper;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\CoreBundle\OrderPay\Provider\UrlProviderInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[AsMessageHandler]
+final class CaptureHostedPaymentRequestHandler
+{
+    public function __construct(
+        private PaymentRequestProviderInterface $paymentRequestProvider,
+        private StateMachineInterface $stateMachine,
+        private HostedPaymentCreatorInterface $hostedPaymentCreator,
+        // Only used by the 3DS-redirect branch below, currently commented out — see the note
+        // there (blocked on unified-plugin-core exposing $successUrl/$cancelUrl).
+        #[Autowire(service: 'sylius_shop.provider.order_pay.after_pay_url')] // @phpstan-ignore-line
+        private UrlProviderInterface $afterPayUrlProvider,
+        private UrlGeneratorInterface $urlGenerator,
+        private LoggerInterface $logger,
+        private RequestStack $requestStack,
+        private IOrderStateMutator $orderStateMutator,
+        // TEMPORARY (PRE-3551 QA testing): hardcoded via env var default rather than resolved
+        // per-merchant. This will be reworked once real UHF account resolution is implemented —
+        // do not treat this as the final design.
+        private string $uhfAccountId,
+        private string $uhfSubmerchantExternalId,
+    ) {
+    }
+
+    public function __invoke(CaptureHostedPaymentRequest $captureHostedPaymentRequest): void
+    {
+        $paymentRequest = $this->paymentRequestProvider->provide($captureHostedPaymentRequest);
+        /** @var \Sylius\Component\Core\Model\PaymentInterface $payment */
+        $payment = $paymentRequest->getPayment();
+        $method = $payment->getMethod();
+        if (null === $method) {
+            throw new \LogicException('Payment method is not set for the payment.');
+        }
+
+        $details = $payment->getDetails();
+        $hfToken = $details['hosted_fields_token'] ?? null;
+        if (!\is_string($hfToken) || '' === $hfToken) {
+            throw new \LogicException('No hosted fields token found on the payment.');
+        }
+
+        $amount = $payment->getAmount();
+        $currencyCode = $payment->getCurrencyCode();
+        if (null === $amount || null === $currencyCode) {
+            throw new \LogicException('Payment amount or currency is not set.');
+        }
+
+        try {
+            $order = $payment->getOrder();
+            $orderId = $order?->getNumber() ?? self::idToString($payment->getId());
+            $firstItemOrFalse = $order?->getItems()->first();
+            $firstItem = false !== $firstItemOrFalse ? $firstItemOrFalse : null;
+
+            $common = new CommonFieldsDto($this->uhfAccountId, $amount, \strtoupper($currencyCode), $orderId, $this->uhfSubmerchantExternalId); // @phpstan-ignore-line
+            $common->description = null !== $firstItem ? $firstItem->getProductName() : null;
+            $common->notificationUrl = $this->urlGenerator->generate(
+                'sylius_payment_request_notify',
+                ['hash' => (string) $paymentRequest->getHash()],
+                UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+            // Blocked on unified-plugin-core exposing $successUrl/$cancelUrl on CommonFieldsDto (see
+            // this plan's "Blocking external prerequisite" section) — uncomment once that lands and
+            // the composer dependency is bumped:
+            // $successUrl = $this->afterPayUrlProvider->getUrl($paymentRequest, UrlGeneratorInterface::ABSOLUTE_URL);
+            // $common->successUrl = $successUrl;
+            // $common->cancelUrl = $successUrl . '?' . http_build_query(['status' => 'canceled']);
+
+            $selectedBrand = $details['hosted_fields_selected_brand'] ?? null;
+            $paymentMethodDetails = \is_string($selectedBrand) && '' !== $selectedBrand
+                ? ['details' => ['selectedBrand' => $selectedBrand]]
+                : null;
+
+            $customer = $order?->getCustomer();
+            if (null === $customer || null === $customer->getEmail()) {
+                throw new \LogicException('Customer email is not set for the payment.');
+            }
+            $customerDto = new CustomerDto(self::idToString($customer->getId()), $customer->getEmail());
+
+            $request = $this->requestStack->getCurrentRequest();
+            $browserDto = null !== $request
+                ? new BrowserDto(
+                    $request->getClientIp() ?? '',
+                    $request->headers->get('referer', '') ?? '',
+                    $request->headers->get('User-Agent', '') ?? '',
+                )
+                : null;
+
+            $dto = new HostedFieldDto($common, $hfToken, $browserDto, $customerDto, $paymentMethodDetails);
+
+            $this->logger->debug('[PayPlug debug] Unified API hosted payment request payload.', [
+                'payload' => $dto->createPayloadBody(),
+            ]);
+
+            $output = $this->hostedPaymentCreator->createHostedPayment($dto);
+        } catch (ApiException | InvalidHostedFieldException | \LogicException $e) {
+            $this->logger->error('[PayPlug][UPC] Hosted payment creation failed.', [
+                'sylius_payment_id' => $payment->getId(),
+                'error' => $e->getMessage(),
+            ]);
+            $paymentRequest->setResponseData(['error' => $e->getMessage()]);
+            $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+            return;
+        }
+
+        $payment->setDetails([
+            ...$details,
+            'hosted_fields_created_at' => (new \DateTimeImmutable())->format(\DateTimeInterface::ATOM),
+        ]);
+
+        if (null !== $output->redirectUrl) {
+            $paymentRequest->setResponseData(['redirect_url' => $output->redirectUrl]);
+        } else {
+            $paymentRequest->setResponseData(['status' => $output->status]);
+
+            // No 3DS redirect means the outcome is already known synchronously — apply it to the
+            // actual Sylius Payment right away instead of waiting on the async webhook, which may
+            // be delayed or, in this test environment, never arrive at all. SyliusOrderStateMutator
+            // is idempotent (checks the state machine before transitioning), so it's safe to also
+            // run again if/when the webhook (NotifyHostedPaymentRequestHandler) eventually shows up.
+            $responseBody = \json_decode($output->body, true);
+            $execCode = \is_array($responseBody) ? ($responseBody['execCode'] ?? null) : null;
+            if (\is_string($execCode)) {
+                $this->orderStateMutator->apply(self::idToString($payment->getId()), ExecCodeMapper::toPaymentOutcome($execCode));
+            }
+        }
+
+        $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+    }
+
+    private static function idToString(mixed $id): string
+    {
+        if (!\is_int($id) && !\is_string($id)) {
+            throw new \LogicException('Unexpected non-scalar resource identifier.');
+        }
+
+        return (string) $id;
+    }
+}

--- a/src/Command/Handler/CaptureHostedPaymentRequestHandler.php
+++ b/src/Command/Handler/CaptureHostedPaymentRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PayPlug\SyliusPayPlugPlugin\Command\Handler;
 
 use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Upc\HostedPaymentCreatorInterface;
 use PayplugUnifiedCore\Contracts\IOrderStateMutator;
 use PayplugUnifiedCore\Dto\BrowserDto;
@@ -39,11 +40,6 @@ final class CaptureHostedPaymentRequestHandler
         private LoggerInterface $logger,
         private RequestStack $requestStack,
         private IOrderStateMutator $orderStateMutator,
-        // TEMPORARY (PRE-3551 QA testing): hardcoded via env var default rather than resolved
-        // per-merchant. This will be reworked once real UHF account resolution is implemented —
-        // do not treat this as the final design.
-        private string $uhfAccountId,
-        private string $uhfSubmerchantExternalId,
     ) {
     }
 
@@ -69,13 +65,20 @@ final class CaptureHostedPaymentRequestHandler
             throw new \LogicException('Payment amount or currency is not set.');
         }
 
+        $gatewayConfig = $method->getGatewayConfig()?->getConfig() ?? [];
+        $accountId = $gatewayConfig[PayPlugGatewayFactory::HF_IDENTIFIER] ?? null;
+        $submerchantExternalId = $gatewayConfig[PayPlugGatewayFactory::HF_SUB_MERCHANT_ID] ?? null;
+        if (!\is_string($accountId) || '' === $accountId || !\is_string($submerchantExternalId) || '' === $submerchantExternalId) {
+            throw new \LogicException('Hosted Fields account id or submerchant id is not configured for this payment method.');
+        }
+
         try {
             $order = $payment->getOrder();
             $orderId = $order?->getNumber() ?? self::idToString($payment->getId());
             $firstItemOrFalse = $order?->getItems()->first();
             $firstItem = false !== $firstItemOrFalse ? $firstItemOrFalse : null;
 
-            $common = new CommonFieldsDto($this->uhfAccountId, $amount, \strtoupper($currencyCode), $orderId, $this->uhfSubmerchantExternalId); // @phpstan-ignore-line
+            $common = new CommonFieldsDto($accountId, $amount, \strtoupper($currencyCode), $orderId, $submerchantExternalId);
             $common->description = null !== $firstItem ? $firstItem->getProductName() : null;
             $common->notificationUrl = $this->urlGenerator->generate(
                 'sylius_payment_request_notify',

--- a/src/Command/Handler/NotifyHostedPaymentRequestHandler.php
+++ b/src/Command/Handler/NotifyHostedPaymentRequestHandler.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\NotifyHostedPaymentRequest;
+use PayplugUnifiedCore\Contracts\IConfigurationRepository;
+use PayplugUnifiedCore\Contracts\ILock;
+use PayplugUnifiedCore\Contracts\IOrderStateMutator;
+use PayplugUnifiedCore\Contracts\IPaymentRepository;
+use PayplugUnifiedCore\Exceptions\InvalidNotificationException;
+use PayplugUnifiedCore\Utilities\Helpers\WebhookNotificationHelper;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class NotifyHostedPaymentRequestHandler
+{
+    // Never currently written by anything in this codebase — no admin form field, OAuth-flow
+    // side-effect, or other mechanism calls IConfigurationRepository::set() for this key. Until
+    // one does (TBD with the backend team: unclear whether PayPlug returns this during OAuth
+    // token exchange or requires separate back-office/admin-field setup), $expectedHeader below
+    // always resolves to an empty string and WebhookNotificationHelper::verifySignature() will
+    // reject every real webhook notification.
+    private const CONFIG_KEY_WEBHOOK_AUTHORIZATION_HEADER = 'payplug_webhook_authorization_header';
+
+    public function __construct(
+        private PaymentRequestProviderInterface $paymentRequestProvider,
+        private StateMachineInterface $stateMachine,
+        private ILock $lock,
+        private IPaymentRepository $paymentRepository,
+        private IOrderStateMutator $orderStateMutator,
+        private IConfigurationRepository $configurationRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(NotifyHostedPaymentRequest $notifyHostedPaymentRequest): void
+    {
+        $paymentRequest = $this->paymentRequestProvider->provide($notifyHostedPaymentRequest);
+        $payload = $paymentRequest->getPayload();
+        $rawBody = $payload['http_request']['content'] ?? null; // @phpstan-ignore-line
+        $rawHeaders = $payload['http_request']['headers'] ?? null; // @phpstan-ignore-line
+        if (!\is_string($rawBody) || !\is_array($rawHeaders)) {
+            throw new \LogicException('Invalid UPC notification payload.');
+        }
+        $headers = $this->flattenHeaders($rawHeaders); // @phpstan-ignore-line
+
+        $lockKey = 'payplug_upc_notify_' . \hash('sha256', $rawBody);
+        if (!$this->lock->acquire($lockKey, 30)) {
+            // Another delivery of the same webhook is already being processed; tell PayPlug it
+            // succeeded so it does not keep retrying.
+            $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+            return;
+        }
+
+        try {
+            $expectedHeader = $this->configurationRepository->get(self::CONFIG_KEY_WEBHOOK_AUTHORIZATION_HEADER) ?? '';
+            $operationData = WebhookNotificationHelper::parse($headers, $rawBody, $expectedHeader);
+
+            $expectedOrderId = (string) $paymentRequest->getPayment()->getId(); // @phpstan-ignore-line
+            $expectedAmount = $paymentRequest->getPayment()->getAmount();
+            if ($operationData->orderId !== $expectedOrderId || $operationData->amount !== $expectedAmount) {
+                $this->logger->error('[PayPlug][UPC] Webhook notification does not match the payment request it was received for.', [
+                    'expected_order_id' => $expectedOrderId,
+                    'received_order_id' => $operationData->orderId,
+                    'expected_amount' => $expectedAmount,
+                    'received_amount' => $operationData->amount,
+                ]);
+                $paymentRequest->setResponseData(['error' => 'Webhook notification does not match the expected payment.']);
+                $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+                return;
+            }
+
+            if ($this->paymentRepository->isTreated($operationData->operationId)) {
+                return;
+            }
+
+            $this->paymentRepository->save($operationData);
+            $this->orderStateMutator->apply($operationData->orderId, $operationData->outcome);
+            $this->paymentRepository->markTreated($operationData->operationId);
+
+            $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+        } catch (InvalidNotificationException $e) {
+            $this->logger->error('[PayPlug][UPC] Rejected webhook notification.', ['error' => $e->getMessage()]);
+            $paymentRequest->setResponseData(['error' => $e->getMessage()]);
+            $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+        } finally {
+            $this->lock->release($lockKey);
+        }
+    }
+
+    /**
+     * @param array<string, array<int, string>> $rawHeaders
+     *
+     * @return array<string, string>
+     */
+    private function flattenHeaders(array $rawHeaders): array
+    {
+        $headers = [];
+        foreach ($rawHeaders as $name => $values) {
+            $headers[$name] = $values[0] ?? '';
+        }
+
+        return $headers;
+    }
+}

--- a/src/Command/Handler/StatusHostedPaymentRequestHandler.php
+++ b/src/Command/Handler/StatusHostedPaymentRequestHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\StatusHostedPaymentRequest;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+use Sylius\Component\Payment\PaymentTransitions;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final class StatusHostedPaymentRequestHandler
+{
+    private const FORCED_STATUS_CANCELED = 'canceled';
+
+    public function __construct(
+        private PaymentRequestProviderInterface $paymentRequestProvider,
+        private StateMachineInterface $stateMachine,
+    ) {
+    }
+
+    public function __invoke(StatusHostedPaymentRequest $statusHostedPaymentRequest): void
+    {
+        $paymentRequest = $this->paymentRequestProvider->provide($statusHostedPaymentRequest);
+
+        if (self::FORCED_STATUS_CANCELED === $statusHostedPaymentRequest->getForcedStatus()) {
+            $payment = $paymentRequest->getPayment();
+            if ($this->stateMachine->can($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)) {
+                $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL);
+            }
+        }
+
+        // No polling against any API: the Payment's current state is whatever the Notify handler
+        // (Task 10) has already applied from the webhook, or still "processing" if none has
+        // arrived yet — this handler never queries UPC/PayPlug for a status.
+        $this->stateMachine->apply($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+    }
+}

--- a/src/Command/NotifyHostedPaymentRequest.php
+++ b/src/Command/NotifyHostedPaymentRequest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command;
+
+class NotifyHostedPaymentRequest extends AbstractPayplugPaymentRequest
+{
+}

--- a/src/Command/Provider/CaptureHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/CaptureHostedPaymentRequestCommandProvider.php
@@ -8,12 +8,12 @@ use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
 use Sylius\Bundle\PaymentBundle\Command\Offline\CapturePaymentRequest as OfflineCapturePaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag(
-    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
-    ['action' => PaymentRequestInterface::ACTION_CAPTURE],
-)]
+/**
+ * Not tagged for direct DI collection: dispatched to only by
+ * CapturePaymentRequestCommandProvider, when the payment method is `payplug` with Hosted Fields
+ * selected (see PayPlugGatewayFactory::isHostedFieldsConfig()).
+ */
 final class CaptureHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Command/Provider/CaptureHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/CaptureHostedPaymentRequestCommandProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
+use Sylius\Bundle\PaymentBundle\Command\Offline\CapturePaymentRequest as OfflineCapturePaymentRequest;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(
+    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
+    ['action' => PaymentRequestInterface::ACTION_CAPTURE],
+)]
+final class CaptureHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
+{
+    public function supports(PaymentRequestInterface $paymentRequest): bool
+    {
+        return $paymentRequest->getAction() === PaymentRequestInterface::ACTION_CAPTURE;
+    }
+
+    public function provide(PaymentRequestInterface $paymentRequest): object
+    {
+        $details = $paymentRequest->getPayment()->getDetails();
+        if (\is_string($details['hosted_fields_created_at'] ?? null)) {
+            // A payment already created via createHostedPayment() (e.g. the shopper returned to
+            // /pay after a 3DS redirect) — do not create it again.
+            return new OfflineCapturePaymentRequest($paymentRequest->getId());
+        }
+
+        return new CaptureHostedPaymentRequest($paymentRequest->getId());
+    }
+}

--- a/src/Command/Provider/CapturePaymentRequestCommandProvider.php
+++ b/src/Command/Provider/CapturePaymentRequestCommandProvider.php
@@ -10,6 +10,7 @@ use Sylius\Bundle\PaymentBundle\Command\Offline\CapturePaymentRequest as Offline
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AutoconfigureTag(
     'payplug_sylius_payplug_plugin.command_provider.payplug',
@@ -41,6 +42,14 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 )]
 final class CapturePaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
+    use DelegatesToHostedFieldsCommandProviderTrait;
+
+    public function __construct(
+        #[Autowire(service: CaptureHostedPaymentRequestCommandProvider::class)]
+        private PaymentRequestCommandProviderInterface $hostedFieldsCommandProvider,
+    ) {
+    }
+
     public function supports(PaymentRequestInterface $paymentRequest): bool
     {
         return $paymentRequest->getAction() === PaymentRequestInterface::ACTION_CAPTURE;
@@ -48,6 +57,11 @@ final class CapturePaymentRequestCommandProvider implements PaymentRequestComman
 
     public function provide(PaymentRequestInterface $paymentRequest): object
     {
+        $hostedFieldsResult = $this->delegateToHostedFieldsCommandProvider($paymentRequest, $this->hostedFieldsCommandProvider);
+        if (null !== $hostedFieldsResult) {
+            return $hostedFieldsResult;
+        }
+
         if ($this->isAlreadyCreated($paymentRequest)) {
             // The payment has already been created, let's use the offline capture request to be redirected to the thank-you page
             return new OfflineCapturePaymentRequest($paymentRequest->getId());

--- a/src/Command/Provider/DelegatesToHostedFieldsCommandProviderTrait.php
+++ b/src/Command/Provider/DelegatesToHostedFieldsCommandProviderTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+/**
+ * Shared by Capture/Notify/StatusPaymentRequestCommandProvider, each tagged (and shared) across
+ * every PayPlug gateway variant (Oney, Bancontact, ...): only a `payplug`-factory payment method
+ * with Hosted Fields selected delegates to the Hosted-Fields-specific provider passed in — every
+ * other gateway gets null here and falls through to that class's own legacy flow, unchanged.
+ */
+trait DelegatesToHostedFieldsCommandProviderTrait
+{
+    private function delegateToHostedFieldsCommandProvider(
+        PaymentRequestInterface $paymentRequest,
+        PaymentRequestCommandProviderInterface $hostedFieldsCommandProvider,
+    ): ?object {
+        if (!PayPlugGatewayFactory::isHostedFieldsConfig($paymentRequest->getPayment()->getMethod()?->getGatewayConfig())) {
+            return null;
+        }
+
+        return $hostedFieldsCommandProvider->provide($paymentRequest);
+    }
+}

--- a/src/Command/Provider/NotifyHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/NotifyHostedPaymentRequestCommandProvider.php
@@ -7,12 +7,12 @@ namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
 use PayPlug\SyliusPayPlugPlugin\Command\NotifyHostedPaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AutoconfigureTag(
-    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
-    ['action' => PaymentRequestInterface::ACTION_NOTIFY],
-)]
+/**
+ * Not tagged for direct DI collection: dispatched to only by
+ * NotifyPaymentRequestCommandProvider, when the payment method is `payplug` with Hosted Fields
+ * selected (see PayPlugGatewayFactory::isHostedFieldsConfig()).
+ */
 final class NotifyHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function supports(PaymentRequestInterface $paymentRequest): bool

--- a/src/Command/Provider/NotifyHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/NotifyHostedPaymentRequestCommandProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\NotifyHostedPaymentRequest;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(
+    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
+    ['action' => PaymentRequestInterface::ACTION_NOTIFY],
+)]
+final class NotifyHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
+{
+    public function supports(PaymentRequestInterface $paymentRequest): bool
+    {
+        return $paymentRequest->getAction() === PaymentRequestInterface::ACTION_NOTIFY;
+    }
+
+    public function provide(PaymentRequestInterface $paymentRequest): object
+    {
+        return new NotifyHostedPaymentRequest($paymentRequest->getId());
+    }
+}

--- a/src/Command/Provider/NotifyPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/NotifyPaymentRequestCommandProvider.php
@@ -8,6 +8,7 @@ use PayPlug\SyliusPayPlugPlugin\Command\NotifyPaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AutoconfigureTag(
     'payplug_sylius_payplug_plugin.command_provider.payplug',
@@ -39,6 +40,14 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 )]
 final class NotifyPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
+    use DelegatesToHostedFieldsCommandProviderTrait;
+
+    public function __construct(
+        #[Autowire(service: NotifyHostedPaymentRequestCommandProvider::class)]
+        private PaymentRequestCommandProviderInterface $hostedFieldsCommandProvider,
+    ) {
+    }
+
     public function supports(PaymentRequestInterface $paymentRequest): bool
     {
         return $paymentRequest->getAction() === PaymentRequestInterface::ACTION_NOTIFY;
@@ -46,6 +55,8 @@ final class NotifyPaymentRequestCommandProvider implements PaymentRequestCommand
 
     public function provide(PaymentRequestInterface $paymentRequest): object
     {
-        return new NotifyPaymentRequest($paymentRequest->getId());
+        $hostedFieldsResult = $this->delegateToHostedFieldsCommandProvider($paymentRequest, $this->hostedFieldsCommandProvider);
+
+        return $hostedFieldsResult ?? new NotifyPaymentRequest($paymentRequest->getId());
     }
 }

--- a/src/Command/Provider/StatusHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/StatusHostedPaymentRequestCommandProvider.php
@@ -7,13 +7,13 @@ namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
 use PayPlug\SyliusPayPlugPlugin\Command\StatusHostedPaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
-use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-#[AutoconfigureTag(
-    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
-    ['action' => PaymentRequestInterface::ACTION_STATUS],
-)]
+/**
+ * Not tagged for direct DI collection: dispatched to only by
+ * StatusPaymentRequestCommandProvider, when the payment method is `payplug` with Hosted Fields
+ * selected (see PayPlugGatewayFactory::isHostedFieldsConfig()).
+ */
 final class StatusHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
     public function __construct(private RequestStack $requestStack)

--- a/src/Command/Provider/StatusHostedPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/StatusHostedPaymentRequestCommandProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\StatusHostedPaymentRequest;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+#[AutoconfigureTag(
+    'payplug_sylius_payplug_plugin.command_provider.payplug_uhf',
+    ['action' => PaymentRequestInterface::ACTION_STATUS],
+)]
+final class StatusHostedPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
+{
+    public function __construct(private RequestStack $requestStack)
+    {
+    }
+
+    public function supports(PaymentRequestInterface $paymentRequest): bool
+    {
+        return $paymentRequest->getAction() === PaymentRequestInterface::ACTION_STATUS;
+    }
+
+    public function provide(PaymentRequestInterface $paymentRequest): object
+    {
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request) {
+            return new StatusHostedPaymentRequest($paymentRequest->getId());
+        }
+
+        return new StatusHostedPaymentRequest($paymentRequest->getId(), $request->query->getString('status'));
+    }
+}

--- a/src/Command/Provider/StatusPaymentRequestCommandProvider.php
+++ b/src/Command/Provider/StatusPaymentRequestCommandProvider.php
@@ -8,6 +8,7 @@ use PayPlug\SyliusPayPlugPlugin\Command\StatusPaymentRequest;
 use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
 use Sylius\Component\Payment\Model\PaymentRequestInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 #[AutoconfigureTag(
@@ -40,8 +41,13 @@ use Symfony\Component\HttpFoundation\RequestStack;
 )]
 final class StatusPaymentRequestCommandProvider implements PaymentRequestCommandProviderInterface
 {
-    public function __construct(private RequestStack $requestStack)
-    {
+    use DelegatesToHostedFieldsCommandProviderTrait;
+
+    public function __construct(
+        private RequestStack $requestStack,
+        #[Autowire(service: StatusHostedPaymentRequestCommandProvider::class)]
+        private PaymentRequestCommandProviderInterface $hostedFieldsCommandProvider,
+    ) {
     }
 
     public function supports(PaymentRequestInterface $paymentRequest): bool
@@ -51,6 +57,11 @@ final class StatusPaymentRequestCommandProvider implements PaymentRequestCommand
 
     public function provide(PaymentRequestInterface $paymentRequest): object
     {
+        $hostedFieldsResult = $this->delegateToHostedFieldsCommandProvider($paymentRequest, $this->hostedFieldsCommandProvider);
+        if (null !== $hostedFieldsResult) {
+            return $hostedFieldsResult;
+        }
+
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {
             return new StatusPaymentRequest($paymentRequest->getId());

--- a/src/Command/StatusHostedPaymentRequest.php
+++ b/src/Command/StatusHostedPaymentRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Command;
+
+class StatusHostedPaymentRequest extends AbstractPayplugPaymentRequest
+{
+    public function __construct(protected ?string $hash, private string $forcedStatus = '')
+    {
+        parent::__construct($hash);
+    }
+
+    public function getForcedStatus(): string
+    {
+        return $this->forcedStatus;
+    }
+}

--- a/src/Entity/PayPlugOperation.php
+++ b/src/Entity/PayPlugOperation.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use PayplugUnifiedCore\DataValues\OperationData;
+
+/**
+ * @ORM\Entity()
+ *
+ * @ORM\Table("payplug_upc_operation")
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'payplug_upc_operation')]
+#[ORM\Index(columns: ['order_id'], name: 'idx_payplug_upc_operation_order_id')]
+class PayPlugOperation
+{
+    /**
+     * @var int|null
+     *
+     * @ORM\Id()
+     *
+     * @ORM\GeneratedValue()
+     *
+     * @ORM\Column(type="integer")
+     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="order_id", type="string")
+     */
+    #[ORM\Column(name: 'order_id', type: Types::STRING)]
+    private $orderId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="operation_id", type="string", unique=true)
+     */
+    #[ORM\Column(name: 'operation_id', type: Types::STRING, unique: true)]
+    private $operationId;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="exec_code", type="string")
+     */
+    #[ORM\Column(name: 'exec_code', type: Types::STRING)]
+    private $execCode;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="outcome", type="string")
+     */
+    #[ORM\Column(name: 'outcome', type: Types::STRING)]
+    private $outcome;
+
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="amount", type="integer")
+     */
+    #[ORM\Column(name: 'amount', type: Types::INTEGER)]
+    private $amount;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="treated", type="boolean")
+     */
+    #[ORM\Column(name: 'treated', type: Types::BOOLEAN)]
+    private $treated = false;
+
+    /**
+     * @var \DateTimeImmutable
+     *
+     * @ORM\Column(name="created_at", type="datetime_immutable")
+     */
+    #[ORM\Column(name: 'created_at', type: Types::DATETIME_IMMUTABLE)]
+    private $createdAt;
+
+    public function __construct(string $orderId, string $operationId, string $execCode, string $outcome, int $amount)
+    {
+        $this->orderId = $orderId;
+        $this->operationId = $operationId;
+        $this->execCode = $execCode;
+        $this->outcome = $outcome;
+        $this->amount = $amount;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOrderId(): string
+    {
+        return $this->orderId;
+    }
+
+    public function getOperationId(): string
+    {
+        return $this->operationId;
+    }
+
+    public function getExecCode(): string
+    {
+        return $this->execCode;
+    }
+
+    public function getOutcome(): string
+    {
+        return $this->outcome;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function isTreated(): bool
+    {
+        return $this->treated;
+    }
+
+    public function markTreated(): void
+    {
+        $this->treated = true;
+    }
+
+    public function toOperationData(): OperationData
+    {
+        return new OperationData($this->operationId, $this->execCode, $this->outcome, $this->amount, $this->orderId);
+    }
+}

--- a/src/EventSubscriber/PostPaymentSelectEventSubscriber.php
+++ b/src/EventSubscriber/PostPaymentSelectEventSubscriber.php
@@ -57,8 +57,10 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
      * (RouteNotFoundException).
      *
      * Both Integrated Payment and Hosted Fields target `sylius_shop_order_pay` (Payum
-     * capture/status for Integrated Payment; the payplug_uhf command-provider pipeline, wired in
-     * PRE-3551, for Hosted Fields) so the payment is actually created/confirmed through UPC.
+     * capture/status for Integrated Payment; for Hosted Fields, the same `payplug`-tagged
+     * Capture/Notify/StatusPaymentRequestCommandProvider trio delegates to their
+     * Hosted-Fields-specific counterparts — see PayPlugGatewayFactory::isHostedFieldsConfig() —
+     * so the payment is actually created/confirmed through UPC.
      */
     public function alterRequestConfigurationForInlineCardCapture(RequestEvent $event): void
     {
@@ -184,10 +186,7 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
 
     private function isHostedFieldsEnabled(PaymentInterface $payment): bool
     {
-        $gatewayConfig = $payment->getMethod()?->getGatewayConfig();
-
-        return PayPlugGatewayFactory::FACTORY_NAME === $gatewayConfig?->getFactoryName() &&
-            true === ($gatewayConfig->getConfig()[PayPlugGatewayFactory::HOSTED_FIELDS] ?? false);
+        return PayPlugGatewayFactory::isHostedFieldsConfig($payment->getMethod()?->getGatewayConfig());
     }
 
     private function getRequestField(Request $request, string $field): string

--- a/src/EventSubscriber/PostPaymentSelectEventSubscriber.php
+++ b/src/EventSubscriber/PostPaymentSelectEventSubscriber.php
@@ -23,8 +23,6 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
 {
     private const CHECKOUT_ROUTE = 'sylius_shop_checkout_select_payment';
 
-    private const UPDATE_ORDER_PAYMENT_ROUTE = 'sylius_shop_order_show';
-
     private const TOKEN_FIELD = 'payplug_integrated_payment_token';
 
     private const HOSTED_FIELDS_TOKEN_FIELD = 'hostedfields_token';
@@ -58,17 +56,9 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
      * checkout state, which has no entry in `sylius_shop.checkout_resolver.route_map`
      * (RouteNotFoundException).
      *
-     * The target route differs per mode:
-     * - Integrated Payment relays a real PayPlug `payment_id`, so the order goes to
-     *   `sylius_shop_order_pay` (Payum capture/status) to be reconciled;
-     * - Hosted Fields relays a Dalenys `hfToken` and has no `payment_id` yet (see
-     *   NullHostedFieldsPaymentProcessor, pending PRE-3551). Reaching `sylius_shop_order_pay`
-     *   would make StatusAction `markNew()`, Payum rebuild the details through Convert and
-     *   CaptureAction issue a real createPayment() API call. It is sent to `sylius_shop_order_show`
-     *   instead: same token-based, guest-friendly access, but Payum is never invoked.
-     *
-     * The Hosted Fields check comes first, mirroring handle()'s dispatch order: a request carrying
-     * both token fields is processed as Hosted Fields, so it must be routed as Hosted Fields too.
+     * Both Integrated Payment and Hosted Fields target `sylius_shop_order_pay` (Payum
+     * capture/status for Integrated Payment; the payplug_uhf command-provider pipeline, wired in
+     * PRE-3551, for Hosted Fields) so the payment is actually created/confirmed through UPC.
      */
     public function alterRequestConfigurationForInlineCardCapture(RequestEvent $event): void
     {
@@ -89,7 +79,7 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
         }
 
         $syliusRequestConfig['redirect'] = [
-            'route' => $this->hasHostedFieldsToken($request) ? self::UPDATE_ORDER_PAYMENT_ROUTE : 'sylius_shop_order_pay',
+            'route' => 'sylius_shop_order_pay',
             'parameters' => ['tokenValue' => 'resource.tokenValue'],
         ];
 
@@ -103,7 +93,7 @@ final class PostPaymentSelectEventSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!\in_array($request->attributes->get('_route'), [self::CHECKOUT_ROUTE, self::UPDATE_ORDER_PAYMENT_ROUTE], true)) {
+        if (self::CHECKOUT_ROUTE !== $request->attributes->get('_route')) {
             return;
         }
 

--- a/src/Gateway/PayPlugGatewayFactory.php
+++ b/src/Gateway/PayPlugGatewayFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PayPlug\SyliusPayPlugPlugin\Gateway;
 
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+
 final class PayPlugGatewayFactory extends AbstractGatewayFactory
 {
     public const FACTORY_NAME = 'payplug';
@@ -87,6 +89,19 @@ final class PayPlugGatewayFactory extends AbstractGatewayFactory
         }
 
         return $missing;
+    }
+
+    /**
+     * True only for a `payplug`-factory gateway config with Hosted Fields selected. Used to
+     * decide, within the single `payplug`-tagged command providers shared by every gateway
+     * (Capture/Notify/StatusPaymentRequestCommandProvider), whether to delegate to the
+     * Hosted-Fields-specific variant instead of the legacy PayPlug SDK flow — other gateways
+     * (Oney, Bancontact, ...) never satisfy this check, so their behavior is unaffected.
+     */
+    public static function isHostedFieldsConfig(?GatewayConfigInterface $gatewayConfig): bool
+    {
+        return self::FACTORY_NAME === $gatewayConfig?->getFactoryName() &&
+            true === ($gatewayConfig->getConfig()[self::HOSTED_FIELDS] ?? false);
     }
 
     private static function isBlank(mixed $value): bool

--- a/src/OrderPay/Provider/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/CaptureHttpResponseProvider.php
@@ -39,10 +39,6 @@ use Symfony\Component\HttpFoundation\Response;
     'payplug_sylius_payplug_plugin.http_response_provider.payplug_wero',
     ['action' => PaymentRequestInterface::ACTION_CAPTURE],
 )]
-#[AutoconfigureTag(
-    'payplug_sylius_payplug_plugin.http_response_provider.payplug_uhf',
-    ['action' => PaymentRequestInterface::ACTION_CAPTURE],
-)]
 class CaptureHttpResponseProvider implements HttpResponseProviderInterface
 {
     public function supports(RequestConfiguration $requestConfiguration, PaymentRequestInterface $paymentRequest): bool

--- a/src/OrderPay/Provider/CaptureHttpResponseProvider.php
+++ b/src/OrderPay/Provider/CaptureHttpResponseProvider.php
@@ -39,6 +39,10 @@ use Symfony\Component\HttpFoundation\Response;
     'payplug_sylius_payplug_plugin.http_response_provider.payplug_wero',
     ['action' => PaymentRequestInterface::ACTION_CAPTURE],
 )]
+#[AutoconfigureTag(
+    'payplug_sylius_payplug_plugin.http_response_provider.payplug_uhf',
+    ['action' => PaymentRequestInterface::ACTION_CAPTURE],
+)]
 class CaptureHttpResponseProvider implements HttpResponseProviderInterface
 {
     public function supports(RequestConfiguration $requestConfiguration, PaymentRequestInterface $paymentRequest): bool

--- a/src/Upc/HostedPaymentCreatorInterface.php
+++ b/src/Upc/HostedPaymentCreatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayplugUnifiedCore\Dto\HostedFieldDto;
+use PayplugUnifiedCore\Exceptions\ApiException;
+use PayplugUnifiedCore\Exceptions\InvalidHostedFieldException;
+use PayplugUnifiedCore\Output\HostedPaymentOutput;
+
+interface HostedPaymentCreatorInterface
+{
+    /**
+     * @throws InvalidHostedFieldException
+     * @throws ApiException
+     */
+    public function createHostedPayment(HostedFieldDto $dto): HostedPaymentOutput;
+}

--- a/src/Upc/SyliusOrderStateMutator.php
+++ b/src/Upc/SyliusOrderStateMutator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepositoryInterface;
+use PayplugUnifiedCore\Contracts\IOrderStateMutator;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+
+final class SyliusOrderStateMutator implements IOrderStateMutator
+{
+    public function __construct(
+        private PaymentRepositoryInterface $paymentRepository,
+        private StateMachineInterface $stateMachine,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function apply(string $orderId, string $outcome): void
+    {
+        /** @var PaymentInterface|null $payment */
+        $payment = $this->paymentRepository->find((int) $orderId);
+        if (null === $payment) {
+            $this->logger->error('[PayPlug][UPC] Cannot apply payment outcome: payment not found.', [
+                'sylius_payment_id' => $orderId,
+                'outcome' => $outcome,
+            ]);
+
+            return;
+        }
+
+        $transition = match ($outcome) {
+            PaymentOutcome::PAID, PaymentOutcome::CAPTURE_REQUIRED => PaymentTransitions::TRANSITION_COMPLETE,
+            PaymentOutcome::AUTHORIZED => PaymentTransitions::TRANSITION_AUTHORIZE,
+            PaymentOutcome::REFUNDED => PaymentTransitions::TRANSITION_REFUND,
+            PaymentOutcome::FAILED => PaymentTransitions::TRANSITION_FAIL,
+            // THREE_DS_PENDING is never actually applied here: the webhook parser never produces
+            // it (see WebhookNotificationHelper's own docblock), and the plugin does not persist
+            // it as a Sylius payment-state transition — the payment simply stays "processing"
+            // until a real outcome arrives.
+            default => null,
+        };
+
+        if (null === $transition) {
+            return;
+        }
+
+        if (!$this->stateMachine->can($payment, PaymentTransitions::GRAPH, $transition)) {
+            $this->logger->warning('[PayPlug][UPC] Cannot apply payment transition (already applied or incompatible with current state).', [
+                'sylius_payment_id' => $orderId,
+                'current_state' => $payment->getState(),
+                'transition' => $transition,
+                'outcome' => $outcome,
+            ]);
+
+            return;
+        }
+
+        $this->stateMachine->apply($payment, PaymentTransitions::GRAPH, $transition);
+    }
+}

--- a/src/Upc/SyliusPaymentOperationRepository.php
+++ b/src/Upc/SyliusPaymentOperationRepository.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PayPlug\SyliusPayPlugPlugin\Entity\PayPlugOperation;
+use PayplugUnifiedCore\Contracts\IPaymentRepository;
+use PayplugUnifiedCore\DataValues\OperationData;
+use PayplugUnifiedCore\Exceptions\PaymentNotFoundException;
+
+final class SyliusPaymentOperationRepository implements IPaymentRepository
+{
+    public function __construct(private EntityManagerInterface $entityManager)
+    {
+    }
+
+    public function getByOrderId(string $orderId): OperationData
+    {
+        $entity = $this->findOneBy(['orderId' => $orderId]);
+        if (null === $entity) {
+            throw new PaymentNotFoundException(\sprintf('No operation for order "%s".', $orderId));
+        }
+
+        return $entity->toOperationData();
+    }
+
+    public function getByOperationId(string $operationId): OperationData
+    {
+        $entity = $this->findOneByOperationId($operationId);
+        if (null === $entity) {
+            throw new PaymentNotFoundException(\sprintf('No operation "%s".', $operationId));
+        }
+
+        return $entity->toOperationData();
+    }
+
+    public function save(OperationData $operationData): void
+    {
+        $entity = $this->findOneByOperationId($operationData->operationId);
+        if (null === $entity) {
+            $entity = new PayPlugOperation(
+                $operationData->orderId,
+                $operationData->operationId,
+                $operationData->execCode,
+                $operationData->outcome,
+                $operationData->amount,
+            );
+            $this->entityManager->persist($entity);
+        }
+
+        $this->entityManager->flush();
+    }
+
+    public function markTreated(string $operationId): void
+    {
+        $entity = $this->findOneByOperationId($operationId);
+        if (null === $entity) {
+            throw new PaymentNotFoundException(\sprintf('No operation "%s".', $operationId));
+        }
+
+        $entity->markTreated();
+        $this->entityManager->flush();
+    }
+
+    public function isTreated(string $operationId): bool
+    {
+        $entity = $this->findOneByOperationId($operationId);
+
+        return null !== $entity && $entity->isTreated();
+    }
+
+    /**
+     * @param array<string, string> $criteria
+     */
+    private function findOneBy(array $criteria): ?PayPlugOperation
+    {
+        /** @var PayPlugOperation|null $entity */
+        $entity = $this->entityManager->getRepository(PayPlugOperation::class)->findOneBy($criteria);
+
+        return $entity;
+    }
+
+    private function findOneByOperationId(string $operationId): ?PayPlugOperation
+    {
+        return $this->findOneBy(['operationId' => $operationId]);
+    }
+}

--- a/src/Upc/SyliusUnifiedApiHttpClient.php
+++ b/src/Upc/SyliusUnifiedApiHttpClient.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayplugUnifiedCore\Contracts\IUnifiedApiHttpClient;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class SyliusUnifiedApiHttpClient implements IUnifiedApiHttpClient
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function get(string $url, array $headers = []): array
+    {
+        return $this->send('GET', $url, ['headers' => $headers]);
+    }
+
+    public function postJson(string $url, array $body, array $headers = []): array
+    {
+        return $this->send('POST', $url, ['json' => $body, 'headers' => $headers]);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array{status: int, body: string}
+     */
+    private function send(string $method, string $url, array $options): array
+    {
+        $this->logger->debug('[PayPlug debug] Unified API raw request.', [
+            'method' => $method,
+            'url' => $url,
+            'headers' => $options['headers'] ?? [],
+            'json' => $options['json'] ?? null,
+        ]);
+
+        try {
+            $response = $this->httpClient->request($method, $url, $options);
+            $status = $response->getStatusCode();
+            $body = $response->getContent(false);
+
+            $this->logger->debug('[PayPlug debug] Unified API raw response.', [
+                'status' => $status,
+                'body' => $body,
+            ]);
+
+            return [
+                'status' => $status,
+                'body' => $body,
+            ];
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->debug('[PayPlug debug] Unified API transport exception.', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return ['status' => 0, 'body' => $e->getMessage()];
+        }
+    }
+}

--- a/src/Upc/SyliusUpcConfigurationRepository.php
+++ b/src/Upc/SyliusUpcConfigurationRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PayPlug\SyliusPayPlugPlugin\Upc;
 
 use Doctrine\ORM\EntityManagerInterface;
-use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayplugUnifiedCore\Contracts\IConfigurationRepository;
 use Sylius\Component\Payment\Model\GatewayConfigInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -48,15 +48,14 @@ final class SyliusUpcConfigurationRepository implements IConfigurationRepository
 
     public function getPublicKeyId(): string
     {
-        $value = $this->findGatewayConfig()->getConfig()['hfIdentifierDefault'] ?? '';
+        $value = $this->findGatewayConfig()->getConfig()[PayPlugGatewayFactory::HF_IDENTIFIER] ?? '';
 
         return \is_string($value) ? $value : '';
     }
 
     /**
-     * Not populated by any current admin field: PRE-3550's checkout template reads
-     * `hfIdentifierDefault` directly and never calls this method. Returns '' until a future
-     * ticket adds a distinct public-key-value config field.
+     * Not populated by any current admin field. Returns '' until a future ticket adds a
+     * distinct public-key-value config field.
      */
     public function getPublicKeyValue(): string
     {
@@ -85,8 +84,8 @@ final class SyliusUpcConfigurationRepository implements IConfigurationRepository
     private function findGatewayConfig(): GatewayConfigInterface
     {
         /** @var GatewayConfigInterface|null $gatewayConfig */
-        $gatewayConfig = $this->gatewayConfigRepository->findOneBy(['factoryName' => UhfGatewayFactory::FACTORY_NAME]);
+        $gatewayConfig = $this->gatewayConfigRepository->findOneBy(['factoryName' => PayPlugGatewayFactory::FACTORY_NAME]);
 
-        return $gatewayConfig ?? throw new \LogicException('No gateway config found for ' . UhfGatewayFactory::FACTORY_NAME . '.');
+        return $gatewayConfig ?? throw new \LogicException('No gateway config found for ' . PayPlugGatewayFactory::FACTORY_NAME . '.');
     }
 }

--- a/src/Upc/SyliusUpcConfigurationRepository.php
+++ b/src/Upc/SyliusUpcConfigurationRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PayplugUnifiedCore\Contracts\IConfigurationRepository;
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class SyliusUpcConfigurationRepository implements IConfigurationRepository
+{
+    public function __construct(
+        private RepositoryInterface $gatewayConfigRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function get(string $key): ?string
+    {
+        $value = $this->findGatewayConfig()->getConfig()[$key] ?? null;
+
+        return \is_string($value) ? $value : null;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $gatewayConfig = $this->findGatewayConfig();
+        $gatewayConfig->setConfig([...$gatewayConfig->getConfig(), $key => $value]);
+        $this->entityManager->flush();
+    }
+
+    public function getClientId(): string
+    {
+        $value = $this->getClientConfig()['client_id'] ?? '';
+
+        return \is_string($value) ? $value : '';
+    }
+
+    public function getClientSecret(): string
+    {
+        $value = $this->getClientConfig()['client_secret'] ?? '';
+
+        return \is_string($value) ? $value : '';
+    }
+
+    public function getPublicKeyId(): string
+    {
+        $value = $this->findGatewayConfig()->getConfig()['hfIdentifierDefault'] ?? '';
+
+        return \is_string($value) ? $value : '';
+    }
+
+    /**
+     * Not populated by any current admin field: PRE-3550's checkout template reads
+     * `hfIdentifierDefault` directly and never calls this method. Returns '' until a future
+     * ticket adds a distinct public-key-value config field.
+     */
+    public function getPublicKeyValue(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getClientConfig(): array
+    {
+        $config = $this->findGatewayConfig()->getConfig();
+        $isLive = true === ($config['live'] ?? false);
+        $rawClientConfig = $isLive ? ($config['live_client'] ?? null) : ($config['test_client'] ?? null);
+
+        if (!\is_array($rawClientConfig)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $clientConfig */
+        $clientConfig = $rawClientConfig;
+
+        return $clientConfig;
+    }
+
+    private function findGatewayConfig(): GatewayConfigInterface
+    {
+        /** @var GatewayConfigInterface|null $gatewayConfig */
+        $gatewayConfig = $this->gatewayConfigRepository->findOneBy(['factoryName' => UhfGatewayFactory::FACTORY_NAME]);
+
+        return $gatewayConfig ?? throw new \LogicException('No gateway config found for ' . UhfGatewayFactory::FACTORY_NAME . '.');
+    }
+}

--- a/src/Upc/SyliusUpcLock.php
+++ b/src/Upc/SyliusUpcLock.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayplugUnifiedCore\Contracts\ILock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+final class SyliusUpcLock implements ILock
+{
+    /** @var array<string, LockInterface> */
+    private array $locks = [];
+
+    public function __construct(private LockFactory $lockFactory)
+    {
+    }
+
+    public function acquire(string $key, int $ttlSeconds): bool
+    {
+        $lock = $this->lockFactory->createLock($key, $ttlSeconds);
+        if (!$lock->acquire(false)) {
+            return false;
+        }
+
+        $this->locks[$key] = $lock;
+
+        return true;
+    }
+
+    public function release(string $key): void
+    {
+        if (isset($this->locks[$key])) {
+            $this->locks[$key]->release();
+            unset($this->locks[$key]);
+        }
+    }
+}

--- a/src/Upc/SyliusUpcLogger.php
+++ b/src/Upc/SyliusUpcLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayplugUnifiedCore\Contracts\ILogger;
+use Psr\Log\LoggerInterface;
+
+final class SyliusUpcLogger implements ILogger
+{
+    public function __construct(private LoggerInterface $psrLogger)
+    {
+    }
+
+    public function debug(string $message, array $context = []): void
+    {
+        $this->psrLogger->debug($message, $context);
+    }
+
+    public function info(string $message, array $context = []): void
+    {
+        $this->psrLogger->info($message, $context);
+    }
+
+    public function error(string $message, array $context = []): void
+    {
+        $this->psrLogger->error($message, $context);
+    }
+}

--- a/src/Upc/UnifiedApiHostedPaymentCreator.php
+++ b/src/Upc/UnifiedApiHostedPaymentCreator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayPlug\SyliusPayPlugPlugin\Upc;
+
+use PayplugUnifiedCore\Auth\TokenManager;
+use PayplugUnifiedCore\Contracts\IConfigurationRepository;
+use PayplugUnifiedCore\Contracts\IUnifiedApiHttpClient;
+use PayplugUnifiedCore\Dto\HostedFieldDto;
+use PayplugUnifiedCore\Output\HostedPaymentOutput;
+use PayplugUnifiedCore\Services\UnifiedApiHostedPaymentService;
+
+final class UnifiedApiHostedPaymentCreator implements HostedPaymentCreatorInterface
+{
+    public function __construct(
+        private IUnifiedApiHttpClient $httpClient,
+        private TokenManager $tokenManager,
+        private IConfigurationRepository $configurationRepository,
+        private string $unifiedApiBaseUrl,
+    ) {
+    }
+
+    public function createHostedPayment(HostedFieldDto $dto): HostedPaymentOutput
+    {
+        $service = new UnifiedApiHostedPaymentService(
+            $this->httpClient,
+            $this->tokenManager,
+            $this->unifiedApiBaseUrl,
+            $this->configurationRepository->getClientId(),
+            $this->configurationRepository->getClientSecret(),
+        );
+
+        return $service->createHostedPayment($dto);
+    }
+}

--- a/tests/PHPUnit/Command/Handler/CaptureHostedPaymentRequestHandlerTest.php
+++ b/tests/PHPUnit/Command/Handler/CaptureHostedPaymentRequestHandlerTest.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerInterface;
 use Sylius\Abstraction\StateMachine\StateMachineInterface;
 use Sylius\Bundle\CoreBundle\OrderPay\Provider\UrlProviderInterface;
 use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Bundle\PayumBundle\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -67,8 +68,6 @@ final class CaptureHostedPaymentRequestHandlerTest extends TestCase
             $this->logger,
             $this->requestStack,
             $this->orderStateMutator,
-            'acct_123',
-            'sub_ext_1',
         );
     }
 
@@ -76,9 +75,15 @@ final class CaptureHostedPaymentRequestHandlerTest extends TestCase
         array $details,
         int $amount = 1000,
         string $currency = 'EUR',
+        ?array $gatewayConfig = ['hfIdentifier' => 'acct_123', 'hfSubMerchantId' => 'sub_ext_1'],
     ): PaymentRequestInterface&MockObject
     {
         $method = $this->createMock(PaymentMethodInterface::class);
+        if (null !== $gatewayConfig) {
+            $config = $this->createMock(GatewayConfigInterface::class);
+            $config->method('getConfig')->willReturn($gatewayConfig);
+            $method->method('getGatewayConfig')->willReturn($config);
+        }
 
         $customer = $this->createMock(CustomerInterface::class);
         $customer->method('getId')->willReturn(7);
@@ -130,6 +135,15 @@ final class CaptureHostedPaymentRequestHandlerTest extends TestCase
         $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
     }
 
+    public function testInvoke_whenGatewayConfigIsMissingAccountOrSubmerchantId_throws(): void
+    {
+        $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc'], gatewayConfig: null);
+
+        $this->expectException(\LogicException::class);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
     public function testInvoke_onApiException_failsThePaymentRequest(): void
     {
         $paymentRequest = $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
@@ -145,6 +159,9 @@ final class CaptureHostedPaymentRequestHandlerTest extends TestCase
     public function testInvoke_whenCustomerEmailIsMissing_failsThePaymentRequestInsteadOfCallingHostedPaymentCreator(): void
     {
         $method = $this->createMock(PaymentMethodInterface::class);
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $gatewayConfig->method('getConfig')->willReturn(['hfIdentifier' => 'acct_123', 'hfSubMerchantId' => 'sub_ext_1']);
+        $method->method('getGatewayConfig')->willReturn($gatewayConfig);
         $customer = $this->createMock(CustomerInterface::class);
         $customer->method('getEmail')->willReturn(null);
         $order = $this->createMock(OrderInterface::class);

--- a/tests/PHPUnit/Command/Handler/CaptureHostedPaymentRequestHandlerTest.php
+++ b/tests/PHPUnit/Command/Handler/CaptureHostedPaymentRequestHandlerTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\Handler\CaptureHostedPaymentRequestHandler;
+use PayPlug\SyliusPayPlugPlugin\Upc\HostedPaymentCreatorInterface;
+use PayplugUnifiedCore\Contracts\IOrderStateMutator;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use PayplugUnifiedCore\Exceptions\ApiException;
+use PayplugUnifiedCore\Output\HostedPaymentOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\CoreBundle\OrderPay\Provider\UrlProviderInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class CaptureHostedPaymentRequestHandlerTest extends TestCase
+{
+    private PaymentRequestProviderInterface&MockObject $paymentRequestProvider;
+
+    private StateMachineInterface&MockObject $stateMachine;
+
+    private HostedPaymentCreatorInterface&MockObject $hostedPaymentCreator;
+
+    private UrlProviderInterface&MockObject $afterPayUrlProvider;
+
+    private UrlGeneratorInterface&MockObject $urlGenerator;
+
+    private LoggerInterface&MockObject $logger;
+
+    private RequestStack&MockObject $requestStack;
+
+    private IOrderStateMutator&MockObject $orderStateMutator;
+
+    private CaptureHostedPaymentRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->paymentRequestProvider = $this->createMock(PaymentRequestProviderInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->hostedPaymentCreator = $this->createMock(HostedPaymentCreatorInterface::class);
+        $this->afterPayUrlProvider = $this->createMock(UrlProviderInterface::class);
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->orderStateMutator = $this->createMock(IOrderStateMutator::class);
+
+        $this->handler = new CaptureHostedPaymentRequestHandler(
+            $this->paymentRequestProvider,
+            $this->stateMachine,
+            $this->hostedPaymentCreator,
+            $this->afterPayUrlProvider,
+            $this->urlGenerator,
+            $this->logger,
+            $this->requestStack,
+            $this->orderStateMutator,
+            'acct_123',
+            'sub_ext_1',
+        );
+    }
+
+    private function paymentRequestWithPayment(
+        array $details,
+        int $amount = 1000,
+        string $currency = 'EUR',
+    ): PaymentRequestInterface&MockObject
+    {
+        $method = $this->createMock(PaymentMethodInterface::class);
+
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getId')->willReturn(7);
+        $customer->method('getEmail')->willReturn('customer@example.com');
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCustomer')->willReturn($customer);
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getId')->willReturn(42);
+        $payment->method('getDetails')->willReturn($details);
+        $payment->method('getMethod')->willReturn($method);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAmount')->willReturn($amount);
+        $payment->method('getCurrencyCode')->willReturn($currency);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $paymentRequest->method('getHash')->willReturn(Uuid::v4());
+
+        $this->paymentRequestProvider->method('provide')->willReturn($paymentRequest);
+
+        return $paymentRequest;
+    }
+
+    public function testInvoke_onDirectSuccess_completesThePaymentRequestWithoutARedirect(): void
+    {
+        $paymentRequest = $this->paymentRequestWithPayment([
+            'hosted_fields_token' => 'hf_token_abc',
+            'hosted_fields_selected_brand' => 'VISA',
+        ]);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')->willReturn(new HostedPaymentOutput(201, '{"id":"pay_1"}', null));
+
+        $paymentRequest->expects(self::once())->method('setResponseData')
+            ->with(self::callback(static fn (array $data): bool => !isset($data['redirect_url'])));
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest($paymentRequest->getId()));
+    }
+
+    public function testInvoke_whenNoHostedFieldsTokenStored_throws(): void
+    {
+        $this->paymentRequestWithPayment([]);
+
+        $this->expectException(\LogicException::class);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onApiException_failsThePaymentRequest(): void
+    {
+        $paymentRequest = $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')->willThrowException(new ApiException('boom'));
+
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_whenCustomerEmailIsMissing_failsThePaymentRequestInsteadOfCallingHostedPaymentCreator(): void
+    {
+        $method = $this->createMock(PaymentMethodInterface::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $customer->method('getEmail')->willReturn(null);
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getCustomer')->willReturn($customer);
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getId')->willReturn(42);
+        $payment->method('getDetails')->willReturn(['hosted_fields_token' => 'hf_token_abc']);
+        $payment->method('getMethod')->willReturn($method);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAmount')->willReturn(1000);
+        $payment->method('getCurrencyCode')->willReturn('EUR');
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $paymentRequest->method('getHash')->willReturn(Uuid::v4());
+        $this->paymentRequestProvider->method('provide')->willReturn($paymentRequest);
+
+        $this->hostedPaymentCreator->expects(self::never())->method('createHostedPayment');
+        $paymentRequest->expects(self::once())->method('setResponseData')
+            ->with(self::callback(static fn (array $data): bool => isset($data['error'])));
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onDirectSuccessWithoutExecCode_neverAppliesOrderStateMutator(): void
+    {
+        $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')->willReturn(new HostedPaymentOutput(201, '{"id":"pay_1"}', null));
+
+        $this->orderStateMutator->expects(self::never())->method('apply');
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onDirectSuccessWithSuccessExecCode_appliesPaidOutcomeToOrderStateMutator(): void
+    {
+        $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')
+            ->willReturn(new HostedPaymentOutput(201, '{"id":"pay_1","execCode":"0000"}', null));
+
+        $this->orderStateMutator->expects(self::once())->method('apply')->with('42', PaymentOutcome::PAID);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onDirectSuccessWithFailureExecCode_appliesFailedOutcomeToOrderStateMutator(): void
+    {
+        $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')
+            ->willReturn(new HostedPaymentOutput(201, '{"id":"pay_1","execCode":"9999"}', null));
+
+        $this->orderStateMutator->expects(self::once())->method('apply')->with('42', PaymentOutcome::FAILED);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onRedirectOutcome_neverAppliesOrderStateMutator(): void
+    {
+        $paymentRequest = $this->paymentRequestWithPayment(['hosted_fields_token' => 'hf_token_abc']);
+
+        $this->hostedPaymentCreator->method('createHostedPayment')
+            ->willReturn(new HostedPaymentOutput(201, '{"id":"pay_1"}', 'https://example.com/3ds'));
+
+        $this->orderStateMutator->expects(self::never())->method('apply');
+        $paymentRequest->expects(self::once())->method('setResponseData')
+            ->with(['redirect_url' => 'https://example.com/3ds']);
+
+        $this->handler->__invoke(new CaptureHostedPaymentRequest(null));
+    }
+}

--- a/tests/PHPUnit/Command/Handler/NotifyHostedPaymentRequestHandlerTest.php
+++ b/tests/PHPUnit/Command/Handler/NotifyHostedPaymentRequestHandlerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\Handler\NotifyHostedPaymentRequestHandler;
+use PayPlug\SyliusPayPlugPlugin\Command\NotifyHostedPaymentRequest;
+use PayplugUnifiedCore\Contracts\IConfigurationRepository;
+use PayplugUnifiedCore\Contracts\ILock;
+use PayplugUnifiedCore\Contracts\IOrderStateMutator;
+use PayplugUnifiedCore\Contracts\IPaymentRepository;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+
+final class NotifyHostedPaymentRequestHandlerTest extends TestCase
+{
+    private PaymentRequestProviderInterface&MockObject $paymentRequestProvider;
+
+    private StateMachineInterface&MockObject $stateMachine;
+
+    private ILock&MockObject $lock;
+
+    private IPaymentRepository&MockObject $paymentRepository;
+
+    private IOrderStateMutator&MockObject $orderStateMutator;
+
+    private IConfigurationRepository&MockObject $configurationRepository;
+
+    private LoggerInterface&MockObject $logger;
+
+    private NotifyHostedPaymentRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->paymentRequestProvider = $this->createMock(PaymentRequestProviderInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->lock = $this->createMock(ILock::class);
+        $this->paymentRepository = $this->createMock(IPaymentRepository::class);
+        $this->orderStateMutator = $this->createMock(IOrderStateMutator::class);
+        $this->configurationRepository = $this->createMock(IConfigurationRepository::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+
+        $this->handler = new NotifyHostedPaymentRequestHandler(
+            $this->paymentRequestProvider,
+            $this->stateMachine,
+            $this->lock,
+            $this->paymentRepository,
+            $this->orderStateMutator,
+            $this->configurationRepository,
+            $this->logger,
+        );
+    }
+
+    private function paymentRequestWithPayload(
+        array $httpRequest,
+        int $paymentId = 42,
+        int $paymentAmount = 1000,
+    ): PaymentRequestInterface&MockObject
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getId')->willReturn($paymentId);
+        $payment->method('getAmount')->willReturn($paymentAmount);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayload')->willReturn(['http_request' => $httpRequest]);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $this->paymentRequestProvider->method('provide')->willReturn($paymentRequest);
+
+        return $paymentRequest;
+    }
+
+    public function testInvoke_onValidNotification_savesTreatsAndAppliesTheOutcome(): void
+    {
+        $body = \json_encode(['id' => 'op_123', 'execCode' => '0000', 'orderId' => '42', 'amount' => 1000]);
+        $paymentRequest = $this->paymentRequestWithPayload([
+            'content' => $body,
+            'headers' => ['Authorization' => ['Bearer shared-secret']],
+        ]);
+
+        $this->configurationRepository->method('get')->with('payplug_webhook_authorization_header')->willReturn('Bearer shared-secret');
+        $this->lock->method('acquire')->willReturn(true);
+        $this->paymentRepository->method('isTreated')->with('op_123')->willReturn(false);
+
+        $this->paymentRepository->expects(self::once())->method('save');
+        $this->paymentRepository->expects(self::once())->method('markTreated')->with('op_123');
+        $this->orderStateMutator->expects(self::once())->method('apply')->with('42', PaymentOutcome::PAID);
+        $this->lock->expects(self::once())->method('release');
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_whenLockIsHeld_releasesNothingAndCompletesWithoutApplying(): void
+    {
+        $paymentRequest = $this->paymentRequestWithPayload(['content' => '{}', 'headers' => []]);
+        $this->lock->method('acquire')->willReturn(false);
+
+        $this->paymentRepository->expects(self::never())->method('save');
+        $this->orderStateMutator->expects(self::never())->method('apply');
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_whenAlreadyTreated_isIdempotentAndDoesNotReapply(): void
+    {
+        $body = \json_encode(['id' => 'op_123', 'execCode' => '0000', 'orderId' => '42', 'amount' => 1000]);
+        $this->paymentRequestWithPayload([
+            'content' => $body,
+            'headers' => ['Authorization' => ['Bearer shared-secret']],
+        ]);
+
+        $this->configurationRepository->method('get')->willReturn('Bearer shared-secret');
+        $this->lock->method('acquire')->willReturn(true);
+        $this->paymentRepository->method('isTreated')->with('op_123')->willReturn(true);
+
+        $this->paymentRepository->expects(self::never())->method('save');
+        $this->orderStateMutator->expects(self::never())->method('apply');
+        $this->lock->expects(self::once())->method('release');
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_whenOrderIdDoesNotMatchThePaymentRequestsOwnPayment_failsWithoutApplyingTheOutcome(): void
+    {
+        // The webhook body claims to be about order/payment "999", but the notify hash this
+        // request arrived on belongs to a PaymentRequest whose own payment id is 42. Applying the
+        // outcome here would mutate the wrong payment.
+        $body = \json_encode(['id' => 'op_123', 'execCode' => '0000', 'orderId' => '999', 'amount' => 1000]);
+        $paymentRequest = $this->paymentRequestWithPayload([
+            'content' => $body,
+            'headers' => ['Authorization' => ['Bearer shared-secret']],
+        ], 42, 1000);
+
+        $this->configurationRepository->method('get')->willReturn('Bearer shared-secret');
+        $this->lock->method('acquire')->willReturn(true);
+
+        $this->paymentRepository->expects(self::never())->method('save');
+        $this->paymentRepository->expects(self::never())->method('markTreated');
+        $this->orderStateMutator->expects(self::never())->method('apply');
+        $this->logger->expects(self::once())->method('error');
+        $this->lock->expects(self::once())->method('release');
+        $paymentRequest->expects(self::once())->method('setResponseData');
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_whenAmountDoesNotMatchThePaymentRequestsOwnPayment_failsWithoutApplyingTheOutcome(): void
+    {
+        $body = \json_encode(['id' => 'op_123', 'execCode' => '0000', 'orderId' => '42', 'amount' => 500]);
+        $paymentRequest = $this->paymentRequestWithPayload([
+            'content' => $body,
+            'headers' => ['Authorization' => ['Bearer shared-secret']],
+        ], 42, 1000);
+
+        $this->configurationRepository->method('get')->willReturn('Bearer shared-secret');
+        $this->lock->method('acquire')->willReturn(true);
+
+        $this->paymentRepository->expects(self::never())->method('save');
+        $this->orderStateMutator->expects(self::never())->method('apply');
+        $this->logger->expects(self::once())->method('error');
+        $this->lock->expects(self::once())->method('release');
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_onInvalidSignature_logsReleasesTheLockAndFailsThePaymentRequest(): void
+    {
+        $paymentRequest = $this->paymentRequestWithPayload([
+            'content' => '{}',
+            'headers' => ['Authorization' => ['Bearer wrong-secret']],
+        ]);
+
+        $this->configurationRepository->method('get')->willReturn('Bearer shared-secret');
+        $this->lock->method('acquire')->willReturn(true);
+
+        $this->logger->expects(self::once())->method('error');
+        $this->lock->expects(self::once())->method('release');
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_FAIL);
+
+        $this->handler->__invoke(new NotifyHostedPaymentRequest(null));
+    }
+}

--- a/tests/PHPUnit/Command/Handler/StatusHostedPaymentRequestHandlerTest.php
+++ b/tests/PHPUnit/Command/Handler/StatusHostedPaymentRequestHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Handler;
+
+use PayPlug\SyliusPayPlugPlugin\Command\Handler\StatusHostedPaymentRequestHandler;
+use PayPlug\SyliusPayPlugPlugin\Command\StatusHostedPaymentRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Bundle\PaymentBundle\Provider\PaymentRequestProviderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Sylius\Component\Payment\PaymentRequestTransitions;
+use Sylius\Component\Payment\PaymentTransitions;
+
+final class StatusHostedPaymentRequestHandlerTest extends TestCase
+{
+    private PaymentRequestProviderInterface&MockObject $paymentRequestProvider;
+
+    private StateMachineInterface&MockObject $stateMachine;
+
+    private StatusHostedPaymentRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->paymentRequestProvider = $this->createMock(PaymentRequestProviderInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->handler = new StatusHostedPaymentRequestHandler($this->paymentRequestProvider, $this->stateMachine);
+    }
+
+    private function paymentRequest(): PaymentRequestInterface&MockObject
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $this->paymentRequestProvider->method('provide')->willReturn($paymentRequest);
+
+        return $paymentRequest;
+    }
+
+    public function testInvoke_withNoForcedStatus_onlyCompletesThePaymentRequest(): void
+    {
+        $paymentRequest = $this->paymentRequest();
+
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+        $this->handler->__invoke(new StatusHostedPaymentRequest(null));
+    }
+
+    public function testInvoke_withForcedCanceledStatus_cancelsThePaymentWhenAllowed(): void
+    {
+        $paymentRequest = $this->paymentRequest();
+        $payment = $paymentRequest->getPayment();
+
+        $this->stateMachine->method('can')->with($payment, PaymentTransitions::GRAPH, PaymentTransitions::TRANSITION_CANCEL)->willReturn(true);
+        $this->stateMachine->expects(self::exactly(2))->method('apply');
+
+        $this->handler->__invoke(new StatusHostedPaymentRequest(null, 'canceled'));
+    }
+
+    public function testInvoke_withForcedCanceledStatus_whenTransitionNotAllowed_stillCompletesThePaymentRequest(): void
+    {
+        $paymentRequest = $this->paymentRequest();
+
+        $this->stateMachine->method('can')->willReturn(false);
+        $this->stateMachine->expects(self::once())->method('apply')
+            ->with($paymentRequest, PaymentRequestTransitions::GRAPH, PaymentRequestTransitions::TRANSITION_COMPLETE);
+
+        $this->handler->__invoke(new StatusHostedPaymentRequest(null, 'canceled'));
+    }
+}

--- a/tests/PHPUnit/Command/Provider/CapturePaymentRequestCommandProviderTest.php
+++ b/tests/PHPUnit/Command/Provider/CapturePaymentRequestCommandProviderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\CaptureHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\CapturePaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\Provider\CapturePaymentRequestCommandProvider;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\PaymentBundle\Command\Offline\CapturePaymentRequest as OfflineCapturePaymentRequest;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class CapturePaymentRequestCommandProviderTest extends TestCase
+{
+    use PaymentRequestWithGatewayConfigTrait;
+
+    private PaymentRequestCommandProviderInterface&MockObject $hostedFieldsCommandProvider;
+
+    private CapturePaymentRequestCommandProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->hostedFieldsCommandProvider = $this->createMock(PaymentRequestCommandProviderInterface::class);
+        $this->provider = new CapturePaymentRequestCommandProvider($this->hostedFieldsCommandProvider);
+    }
+
+    public function testProvide_forPayplugWithHostedFieldsEnabled_delegatesToHostedFieldsProvider(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => PayPlugGatewayFactory::FACTORY_NAME,
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+
+        $expected = new CaptureHostedPaymentRequest('1');
+        $this->hostedFieldsCommandProvider->expects(self::once())->method('provide')
+            ->with($paymentRequest)->willReturn($expected);
+
+        self::assertSame($expected, $this->provider->provide($paymentRequest));
+    }
+
+    public function testProvide_forPayplugWithoutHostedFields_usesLegacyFlow(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => PayPlugGatewayFactory::FACTORY_NAME,
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => false],
+        ]);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(CapturePaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    /**
+     * Other gateways (Oney, Bancontact, ...) never satisfy the Hosted Fields check regardless of
+     * their own config shape, since it's gated on the `payplug` factory name first — behavior for
+     * them must stay exactly as it was before this delegation was introduced.
+     */
+    public function testProvide_forOtherGatewayFactory_neverDelegatesEvenIfConfigHappensToHaveHostedFieldsKey(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => 'payplug_oney',
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(CapturePaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testProvide_whenNoGatewayConfig_usesLegacyFlow(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig(null);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(CapturePaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testProvide_whenAlreadyCreated_returnsOfflineCaptureRequest(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig(
+            ['factoryName' => PayPlugGatewayFactory::FACTORY_NAME, 'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => false]],
+            ['status' => 'captured', 'payment_id' => 'pay_1'],
+        );
+
+        self::assertInstanceOf(OfflineCapturePaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testSupports_onlyForCaptureAction(): void
+    {
+        $captureRequest = $this->createMock(PaymentRequestInterface::class);
+        $captureRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        self::assertTrue($this->provider->supports($captureRequest));
+
+        $notifyRequest = $this->createMock(PaymentRequestInterface::class);
+        $notifyRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_NOTIFY);
+        self::assertFalse($this->provider->supports($notifyRequest));
+    }
+}

--- a/tests/PHPUnit/Command/Provider/NotifyPaymentRequestCommandProviderTest.php
+++ b/tests/PHPUnit/Command/Provider/NotifyPaymentRequestCommandProviderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\NotifyHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\NotifyPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\Provider\NotifyPaymentRequestCommandProvider;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+final class NotifyPaymentRequestCommandProviderTest extends TestCase
+{
+    use PaymentRequestWithGatewayConfigTrait;
+
+    private PaymentRequestCommandProviderInterface&MockObject $hostedFieldsCommandProvider;
+
+    private NotifyPaymentRequestCommandProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->hostedFieldsCommandProvider = $this->createMock(PaymentRequestCommandProviderInterface::class);
+        $this->provider = new NotifyPaymentRequestCommandProvider($this->hostedFieldsCommandProvider);
+    }
+
+    public function testProvide_forPayplugWithHostedFieldsEnabled_delegatesToHostedFieldsProvider(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => PayPlugGatewayFactory::FACTORY_NAME,
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+
+        $expected = new NotifyHostedPaymentRequest('1');
+        $this->hostedFieldsCommandProvider->expects(self::once())->method('provide')
+            ->with($paymentRequest)->willReturn($expected);
+
+        self::assertSame($expected, $this->provider->provide($paymentRequest));
+    }
+
+    /**
+     * Other gateways (Oney, Bancontact, ...) never satisfy the Hosted Fields check regardless of
+     * their own config shape, since it's gated on the `payplug` factory name first — behavior for
+     * them must stay exactly as it was before this delegation was introduced.
+     */
+    public function testProvide_forOtherGatewayFactory_neverDelegatesEvenIfConfigHappensToHaveHostedFieldsKey(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => 'payplug_oney',
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(NotifyPaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testProvide_whenNoGatewayConfig_usesLegacyFlow(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig(null);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(NotifyPaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testSupports_onlyForNotifyAction(): void
+    {
+        $notifyRequest = $this->createMock(PaymentRequestInterface::class);
+        $notifyRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_NOTIFY);
+        self::assertTrue($this->provider->supports($notifyRequest));
+
+        $captureRequest = $this->createMock(PaymentRequestInterface::class);
+        $captureRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        self::assertFalse($this->provider->supports($captureRequest));
+    }
+}

--- a/tests/PHPUnit/Command/Provider/PaymentRequestWithGatewayConfigTrait.php
+++ b/tests/PHPUnit/Command/Provider/PaymentRequestWithGatewayConfigTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Provider;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Model\PaymentMethodInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+
+/**
+ * Shared by the Capture/Notify/StatusPaymentRequestCommandProvider tests: builds a mocked
+ * PaymentRequest for a payment method with (or without) a given gateway factory name/config.
+ */
+trait PaymentRequestWithGatewayConfigTrait
+{
+    /**
+     * @param array{factoryName: string, config: array<string, mixed>}|null $gatewayConfig
+     * @param array<string, mixed> $details
+     */
+    private function paymentRequestWithConfig(
+        ?array $gatewayConfig,
+        array $details = [],
+    ): PaymentRequestInterface&MockObject
+    {
+        $method = $this->createMock(PaymentMethodInterface::class);
+        if (null !== $gatewayConfig) {
+            $config = $this->createMock(GatewayConfigInterface::class);
+            $config->method('getFactoryName')->willReturn($gatewayConfig['factoryName']);
+            $config->method('getConfig')->willReturn($gatewayConfig['config']);
+            $method->method('getGatewayConfig')->willReturn($config);
+        }
+
+        $payment = $this->createMock(PaymentInterface::class);
+        $payment->method('getMethod')->willReturn($method);
+        $payment->method('getDetails')->willReturn($details);
+
+        $paymentRequest = $this->createMock(PaymentRequestInterface::class);
+        $paymentRequest->method('getPayment')->willReturn($payment);
+        $paymentRequest->method('getId')->willReturn('1');
+
+        return $paymentRequest;
+    }
+}

--- a/tests/PHPUnit/Command/Provider/StatusPaymentRequestCommandProviderTest.php
+++ b/tests/PHPUnit/Command/Provider/StatusPaymentRequestCommandProviderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Command\Provider;
+
+use PayPlug\SyliusPayPlugPlugin\Command\Provider\StatusPaymentRequestCommandProvider;
+use PayPlug\SyliusPayPlugPlugin\Command\StatusHostedPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Command\StatusPaymentRequest;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\PaymentBundle\CommandProvider\PaymentRequestCommandProviderInterface;
+use Sylius\Component\Payment\Model\PaymentRequestInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class StatusPaymentRequestCommandProviderTest extends TestCase
+{
+    use PaymentRequestWithGatewayConfigTrait;
+
+    private RequestStack&MockObject $requestStack;
+
+    private PaymentRequestCommandProviderInterface&MockObject $hostedFieldsCommandProvider;
+
+    private StatusPaymentRequestCommandProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->requestStack = $this->createMock(RequestStack::class);
+        $this->hostedFieldsCommandProvider = $this->createMock(PaymentRequestCommandProviderInterface::class);
+        $this->provider = new StatusPaymentRequestCommandProvider($this->requestStack, $this->hostedFieldsCommandProvider);
+    }
+
+    public function testProvide_forPayplugWithHostedFieldsEnabled_delegatesToHostedFieldsProvider(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => PayPlugGatewayFactory::FACTORY_NAME,
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+
+        $expected = new StatusHostedPaymentRequest('1');
+        $this->hostedFieldsCommandProvider->expects(self::once())->method('provide')
+            ->with($paymentRequest)->willReturn($expected);
+        $this->requestStack->expects(self::never())->method('getCurrentRequest');
+
+        self::assertSame($expected, $this->provider->provide($paymentRequest));
+    }
+
+    /**
+     * Other gateways (Oney, Bancontact, ...) never satisfy the Hosted Fields check regardless of
+     * their own config shape, since it's gated on the `payplug` factory name first — behavior for
+     * them must stay exactly as it was before this delegation was introduced.
+     */
+    public function testProvide_forOtherGatewayFactory_neverDelegatesEvenIfConfigHappensToHaveHostedFieldsKey(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig([
+            'factoryName' => 'payplug_oney',
+            'config' => [PayPlugGatewayFactory::HOSTED_FIELDS => true],
+        ]);
+        $this->requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(StatusPaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testProvide_whenNoGatewayConfig_usesLegacyFlow(): void
+    {
+        $paymentRequest = $this->paymentRequestWithConfig(null);
+        $this->requestStack->method('getCurrentRequest')->willReturn(null);
+
+        $this->hostedFieldsCommandProvider->expects(self::never())->method('provide');
+
+        self::assertInstanceOf(StatusPaymentRequest::class, $this->provider->provide($paymentRequest));
+    }
+
+    public function testSupports_onlyForStatusAction(): void
+    {
+        $statusRequest = $this->createMock(PaymentRequestInterface::class);
+        $statusRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_STATUS);
+        self::assertTrue($this->provider->supports($statusRequest));
+
+        $captureRequest = $this->createMock(PaymentRequestInterface::class);
+        $captureRequest->method('getAction')->willReturn(PaymentRequestInterface::ACTION_CAPTURE);
+        self::assertFalse($this->provider->supports($captureRequest));
+    }
+}

--- a/tests/PHPUnit/Entity/PayPlugOperationTest.php
+++ b/tests/PHPUnit/Entity/PayPlugOperationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Entity;
+
+use PayPlug\SyliusPayPlugPlugin\Entity\PayPlugOperation;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use PHPUnit\Framework\TestCase;
+
+final class PayPlugOperationTest extends TestCase
+{
+    public function testConstruct_setsAllFieldsAndDefaultsTreatedToFalse(): void
+    {
+        $operation = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+
+        self::assertSame('42', $operation->getOrderId());
+        self::assertSame('op_123', $operation->getOperationId());
+        self::assertSame('0000', $operation->getExecCode());
+        self::assertSame(PaymentOutcome::PAID, $operation->getOutcome());
+        self::assertSame(1000, $operation->getAmount());
+        self::assertFalse($operation->isTreated());
+    }
+
+    public function testMarkTreated_setsTreatedToTrue(): void
+    {
+        $operation = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+
+        $operation->markTreated();
+
+        self::assertTrue($operation->isTreated());
+    }
+
+    public function testToOperationData_returnsEquivalentValueObject(): void
+    {
+        $operation = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+
+        $data = $operation->toOperationData();
+
+        self::assertSame('op_123', $data->operationId);
+        self::assertSame('0000', $data->execCode);
+        self::assertSame(PaymentOutcome::PAID, $data->outcome);
+        self::assertSame(1000, $data->amount);
+        self::assertSame('42', $data->orderId);
+    }
+}

--- a/tests/PHPUnit/EventSubscriber/PostPaymentSelectEventSubscriberTest.php
+++ b/tests/PHPUnit/EventSubscriber/PostPaymentSelectEventSubscriberTest.php
@@ -292,12 +292,11 @@ final class PostPaymentSelectEventSubscriberTest extends TestCase
     }
 
     /**
-     * Hosted Fields has no PayPlug payment_id yet (PRE-3551): reaching `sylius_shop_order_pay` would
-     * make StatusAction markNew() and end up issuing a real createPayment() API call. A `redirect`
-     * entry is still required (Sylius's CheckoutRedirectListener would otherwise fail to resolve a
-     * route for the `completed` checkout state), so it points at `sylius_shop_order_show` instead.
+     * Both Integrated Payment and Hosted Fields target `sylius_shop_order_pay` (Payum
+     * capture/status for Integrated Payment; the payplug_uhf command-provider pipeline, wired in
+     * PRE-3551, for Hosted Fields) so the payment is actually created/confirmed through UPC.
      */
-    public function testAlterRequestConfiguration_withOnlyHostedFieldsToken_redirectsToOrderShowNotOrderPay(): void
+    public function testAlterRequestConfigurationForInlineCardCapture_forHostedFieldsToken_redirectsToOrderPay(): void
     {
         $request = Request::create('/checkout/select-payment', 'POST', [
             'hostedfields_token' => 'hf_token_abc',
@@ -311,7 +310,7 @@ final class PostPaymentSelectEventSubscriberTest extends TestCase
         self::assertSame(
             [
                 'redirect' => [
-                    'route' => 'sylius_shop_order_show',
+                    'route' => 'sylius_shop_order_pay',
                     'parameters' => ['tokenValue' => 'resource.tokenValue'],
                 ],
             ],
@@ -321,11 +320,11 @@ final class PostPaymentSelectEventSubscriberTest extends TestCase
 
     /**
      * A crafted request carrying both token fields is dispatched as Hosted Fields by handle()
-     * (it checks hasHostedFieldsToken() first), so it must be routed as Hosted Fields too —
-     * otherwise no payment_id is ever set and the order still lands on the Payum capture/status
-     * chain this redirect exists to avoid.
+     * (it checks hasHostedFieldsToken() first). Since PRE-3551 both paths redirect to the same
+     * route, so this just pins that the redirect override still applies regardless of which
+     * token(s) are present.
      */
-    public function testAlterRequestConfiguration_withBothTokens_followsHandleAndRedirectsToOrderShow(): void
+    public function testAlterRequestConfiguration_withBothTokens_followsHandleAndRedirectsToOrderPay(): void
     {
         $request = Request::create('/checkout/select-payment', 'POST', [
             'payplug_integrated_payment_token' => 'pay_123',
@@ -337,7 +336,7 @@ final class PostPaymentSelectEventSubscriberTest extends TestCase
         $this->subscriber->alterRequestConfigurationForInlineCardCapture($this->buildRequestEvent($request));
 
         $syliusRequestConfig = $request->attributes->get('_sylius');
-        self::assertSame('sylius_shop_order_show', $syliusRequestConfig['redirect']['route']);
+        self::assertSame('sylius_shop_order_pay', $syliusRequestConfig['redirect']['route']);
     }
 
     public function testAlterRequestConfiguration_withoutAnyToken_leavesRedirectUntouched(): void

--- a/tests/PHPUnit/EventSubscriber/PostPaymentSelectEventSubscriberTest.php
+++ b/tests/PHPUnit/EventSubscriber/PostPaymentSelectEventSubscriberTest.php
@@ -293,8 +293,10 @@ final class PostPaymentSelectEventSubscriberTest extends TestCase
 
     /**
      * Both Integrated Payment and Hosted Fields target `sylius_shop_order_pay` (Payum
-     * capture/status for Integrated Payment; the payplug_uhf command-provider pipeline, wired in
-     * PRE-3551, for Hosted Fields) so the payment is actually created/confirmed through UPC.
+     * capture/status for Integrated Payment; for Hosted Fields, the same `payplug`-tagged
+     * Capture/Notify/StatusPaymentRequestCommandProvider trio delegates to their
+     * Hosted-Fields-specific counterparts — see PayPlugGatewayFactory::isHostedFieldsConfig() —
+     * so the payment is actually created/confirmed through UPC.
      */
     public function testAlterRequestConfigurationForInlineCardCapture_forHostedFieldsToken_redirectsToOrderPay(): void
     {

--- a/tests/PHPUnit/Upc/SyliusOrderStateMutatorTest.php
+++ b/tests/PHPUnit/Upc/SyliusOrderStateMutatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Repository\PaymentRepositoryInterface;
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusOrderStateMutator;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Abstraction\StateMachine\StateMachineInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+
+final class SyliusOrderStateMutatorTest extends TestCase
+{
+    private PaymentRepositoryInterface&MockObject $paymentRepository;
+
+    private StateMachineInterface&MockObject $stateMachine;
+
+    private LoggerInterface&MockObject $logger;
+
+    private SyliusOrderStateMutator $mutator;
+
+    protected function setUp(): void
+    {
+        $this->paymentRepository = $this->createMock(PaymentRepositoryInterface::class);
+        $this->stateMachine = $this->createMock(StateMachineInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->mutator = new SyliusOrderStateMutator($this->paymentRepository, $this->stateMachine, $this->logger);
+    }
+
+    /**
+     * @dataProvider outcomeToTransitionProvider
+     */
+    public function testApply_mapsOutcomeToTheExpectedTransition(string $outcome, string $expectedTransition): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $this->paymentRepository->method('find')->with(42)->willReturn($payment);
+        $this->stateMachine->method('can')->with($payment, PaymentTransitions::GRAPH, $expectedTransition)->willReturn(true);
+        $this->stateMachine->expects(self::once())->method('apply')->with($payment, PaymentTransitions::GRAPH, $expectedTransition);
+
+        $this->mutator->apply('42', $outcome);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function outcomeToTransitionProvider(): iterable
+    {
+        yield 'paid' => [PaymentOutcome::PAID, PaymentTransitions::TRANSITION_COMPLETE];
+        yield 'capture_required' => [PaymentOutcome::CAPTURE_REQUIRED, PaymentTransitions::TRANSITION_COMPLETE];
+        yield 'authorized' => [PaymentOutcome::AUTHORIZED, PaymentTransitions::TRANSITION_AUTHORIZE];
+        yield 'refunded' => [PaymentOutcome::REFUNDED, PaymentTransitions::TRANSITION_REFUND];
+        yield 'failed' => [PaymentOutcome::FAILED, PaymentTransitions::TRANSITION_FAIL];
+    }
+
+    public function testApply_forThreeDsPending_doesNothing(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $this->paymentRepository->method('find')->willReturn($payment);
+        $this->stateMachine->expects(self::never())->method('apply');
+
+        $this->mutator->apply('42', PaymentOutcome::THREE_DS_PENDING);
+    }
+
+    public function testApply_whenPaymentNotFound_logsAndDoesNothing(): void
+    {
+        $this->paymentRepository->method('find')->with(42)->willReturn(null);
+        $this->logger->expects(self::once())->method('error');
+        $this->stateMachine->expects(self::never())->method('apply');
+
+        $this->mutator->apply('42', PaymentOutcome::PAID);
+    }
+
+    public function testApply_whenTransitionNotAllowed_logsAndDoesNotApply(): void
+    {
+        $payment = $this->createMock(PaymentInterface::class);
+        $this->paymentRepository->method('find')->willReturn($payment);
+        $this->stateMachine->method('can')->willReturn(false);
+        $this->logger->expects(self::once())->method('warning');
+        $this->stateMachine->expects(self::never())->method('apply');
+
+        $this->mutator->apply('42', PaymentOutcome::PAID);
+    }
+}

--- a/tests/PHPUnit/Upc/SyliusPaymentOperationRepositoryTest.php
+++ b/tests/PHPUnit/Upc/SyliusPaymentOperationRepositoryTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use PayPlug\SyliusPayPlugPlugin\Entity\PayPlugOperation;
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusPaymentOperationRepository;
+use PayplugUnifiedCore\DataValues\OperationData;
+use PayplugUnifiedCore\DataValues\PaymentOutcome;
+use PayplugUnifiedCore\Exceptions\PaymentNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SyliusPaymentOperationRepositoryTest extends TestCase
+{
+    private EntityManagerInterface&MockObject $entityManager;
+
+    private EntityRepository&MockObject $doctrineRepository;
+
+    private SyliusPaymentOperationRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->doctrineRepository = $this->createMock(EntityRepository::class);
+        $this->entityManager->method('getRepository')->with(PayPlugOperation::class)->willReturn($this->doctrineRepository);
+        $this->repository = new SyliusPaymentOperationRepository($this->entityManager);
+    }
+
+    public function testGetByOrderId_whenFound_returnsOperationData(): void
+    {
+        $entity = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+        $this->doctrineRepository->method('findOneBy')->with(['orderId' => '42'])->willReturn($entity);
+
+        $result = $this->repository->getByOrderId('42');
+
+        self::assertSame('op_123', $result->operationId);
+    }
+
+    public function testGetByOrderId_whenMissing_throwsPaymentNotFoundException(): void
+    {
+        $this->doctrineRepository->method('findOneBy')->with(['orderId' => '42'])->willReturn(null);
+
+        $this->expectException(PaymentNotFoundException::class);
+
+        $this->repository->getByOrderId('42');
+    }
+
+    public function testGetByOperationId_whenFound_returnsOperationData(): void
+    {
+        $entity = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn($entity);
+
+        $result = $this->repository->getByOperationId('op_123');
+
+        self::assertSame('42', $result->orderId);
+    }
+
+    public function testGetByOperationId_whenMissing_throwsPaymentNotFoundException(): void
+    {
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn(null);
+
+        $this->expectException(PaymentNotFoundException::class);
+
+        $this->repository->getByOperationId('op_123');
+    }
+
+    public function testSave_persistsAndFlushesANewEntity(): void
+    {
+        $data = new OperationData('op_123', '0000', PaymentOutcome::PAID, 1000, '42');
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn(null);
+
+        $this->entityManager->expects(self::once())->method('persist')
+            ->with(self::isInstanceOf(PayPlugOperation::class));
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->repository->save($data);
+    }
+
+    public function testIsTreated_delegatesToTheStoredEntity(): void
+    {
+        $entity = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+        $entity->markTreated();
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn($entity);
+
+        self::assertTrue($this->repository->isTreated('op_123'));
+    }
+
+    public function testIsTreated_whenMissing_returnsFalse(): void
+    {
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn(null);
+
+        self::assertFalse($this->repository->isTreated('op_123'));
+    }
+
+    public function testMarkTreated_flagsTheStoredEntityAndFlushes(): void
+    {
+        $entity = new PayPlugOperation('42', 'op_123', '0000', PaymentOutcome::PAID, 1000);
+        $this->doctrineRepository->method('findOneBy')->with(['operationId' => 'op_123'])->willReturn($entity);
+
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->repository->markTreated('op_123');
+
+        self::assertTrue($entity->isTreated());
+    }
+}

--- a/tests/PHPUnit/Upc/SyliusUnifiedApiHttpClientTest.php
+++ b/tests/PHPUnit/Upc/SyliusUnifiedApiHttpClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusUnifiedApiHttpClient;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class SyliusUnifiedApiHttpClientTest extends TestCase
+{
+    private HttpClientInterface&MockObject $httpClient;
+
+    private LoggerInterface&MockObject $logger;
+
+    private SyliusUnifiedApiHttpClient $adapter;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->adapter = new SyliusUnifiedApiHttpClient($this->httpClient, $this->logger);
+    }
+
+    public function testGet_sendsGetRequestWithHeaders(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(200);
+        $response->method('getContent')->with(false)->willReturn('{"id":"pay_123"}');
+
+        $this->httpClient->expects(self::once())->method('request')
+            ->with('GET', 'https://api.payplug.com/payments/pay_123', ['headers' => ['Authorization' => 'Bearer jwt']])
+            ->willReturn($response);
+
+        $result = $this->adapter->get('https://api.payplug.com/payments/pay_123', ['Authorization' => 'Bearer jwt']);
+
+        self::assertSame(['status' => 200, 'body' => '{"id":"pay_123"}'], $result);
+    }
+
+    public function testPostJson_sendsJsonEncodedBody(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn(201);
+        $response->method('getContent')->with(false)->willReturn('{"id":"pay_123"}');
+
+        $this->httpClient->expects(self::once())->method('request')
+            ->with('POST', 'https://api.payplug.com/payments', [
+                'json' => ['amount' => 1000],
+                'headers' => ['Authorization' => 'Bearer jwt'],
+            ])
+            ->willReturn($response);
+
+        $result = $this->adapter->postJson('https://api.payplug.com/payments', ['amount' => 1000], ['Authorization' => 'Bearer jwt']);
+
+        self::assertSame(['status' => 201, 'body' => '{"id":"pay_123"}'], $result);
+    }
+
+    public function testGet_onTransportFailure_returnsZeroStatusInsteadOfThrowing(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willThrowException(new TransportException('Could not resolve host'));
+        $this->httpClient->method('request')->willReturn($response);
+
+        $result = $this->adapter->get('https://api.payplug.com/payments/pay_123');
+
+        self::assertSame(0, $result['status']);
+        self::assertSame('Could not resolve host', $result['body']);
+    }
+
+    public function testPostJson_onTransportFailure_returnsZeroStatusInsteadOfThrowing(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willThrowException(new TransportException('Could not resolve host'));
+        $this->httpClient->method('request')->willReturn($response);
+
+        $result = $this->adapter->postJson('https://api.payplug.com/payments', []);
+
+        self::assertSame(0, $result['status']);
+        self::assertSame('Could not resolve host', $result['body']);
+    }
+}

--- a/tests/PHPUnit/Upc/SyliusUpcConfigurationRepositoryTest.php
+++ b/tests/PHPUnit/Upc/SyliusUpcConfigurationRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
 
 use Doctrine\ORM\EntityManagerInterface;
-use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Gateway\PayPlugGatewayFactory;
 use PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcConfigurationRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -32,7 +32,7 @@ final class SyliusUpcConfigurationRepositoryTest extends TestCase
         $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
         $gatewayConfig->method('getConfig')->willReturn($config);
         $this->gatewayConfigRepository->method('findOneBy')
-            ->with(['factoryName' => UhfGatewayFactory::FACTORY_NAME])
+            ->with(['factoryName' => PayPlugGatewayFactory::FACTORY_NAME])
             ->willReturn($gatewayConfig);
 
         return $gatewayConfig;
@@ -66,9 +66,9 @@ final class SyliusUpcConfigurationRepositoryTest extends TestCase
         self::assertSame('', $this->configurationRepository->getClientId());
     }
 
-    public function testGetPublicKeyId_readsHfIdentifierDefault(): void
+    public function testGetPublicKeyId_readsHfIdentifier(): void
     {
-        $this->gatewayConfigWith(['hfIdentifierDefault' => 'hf_ident_123']);
+        $this->gatewayConfigWith([PayPlugGatewayFactory::HF_IDENTIFIER => 'hf_ident_123']);
 
         self::assertSame('hf_ident_123', $this->configurationRepository->getPublicKeyId());
     }

--- a/tests/PHPUnit/Upc/SyliusUpcConfigurationRepositoryTest.php
+++ b/tests/PHPUnit/Upc/SyliusUpcConfigurationRepositoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PayPlug\SyliusPayPlugPlugin\Gateway\UhfGatewayFactory;
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcConfigurationRepository;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Payment\Model\GatewayConfigInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class SyliusUpcConfigurationRepositoryTest extends TestCase
+{
+    private RepositoryInterface&MockObject $gatewayConfigRepository;
+
+    private EntityManagerInterface&MockObject $entityManager;
+
+    private SyliusUpcConfigurationRepository $configurationRepository;
+
+    protected function setUp(): void
+    {
+        $this->gatewayConfigRepository = $this->createMock(RepositoryInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->configurationRepository = new SyliusUpcConfigurationRepository($this->gatewayConfigRepository, $this->entityManager);
+    }
+
+    private function gatewayConfigWith(array $config): GatewayConfigInterface&MockObject
+    {
+        $gatewayConfig = $this->createMock(GatewayConfigInterface::class);
+        $gatewayConfig->method('getConfig')->willReturn($config);
+        $this->gatewayConfigRepository->method('findOneBy')
+            ->with(['factoryName' => UhfGatewayFactory::FACTORY_NAME])
+            ->willReturn($gatewayConfig);
+
+        return $gatewayConfig;
+    }
+
+    public function testGetClientId_whenLive_readsFromLiveClient(): void
+    {
+        $this->gatewayConfigWith(['live' => true, 'live_client' => ['client_id' => 'live_id', 'client_secret' => 'live_secret']]);
+
+        self::assertSame('live_id', $this->configurationRepository->getClientId());
+    }
+
+    public function testGetClientId_whenNotLive_readsFromTestClient(): void
+    {
+        $this->gatewayConfigWith(['live' => false, 'test_client' => ['client_id' => 'test_id', 'client_secret' => 'test_secret']]);
+
+        self::assertSame('test_id', $this->configurationRepository->getClientId());
+    }
+
+    public function testGetClientSecret_whenLive_readsFromLiveClient(): void
+    {
+        $this->gatewayConfigWith(['live' => true, 'live_client' => ['client_id' => 'live_id', 'client_secret' => 'live_secret']]);
+
+        self::assertSame('live_secret', $this->configurationRepository->getClientSecret());
+    }
+
+    public function testGetClientId_whenNoClientConfigStored_returnsEmptyString(): void
+    {
+        $this->gatewayConfigWith(['live' => false]);
+
+        self::assertSame('', $this->configurationRepository->getClientId());
+    }
+
+    public function testGetPublicKeyId_readsHfIdentifierDefault(): void
+    {
+        $this->gatewayConfigWith(['hfIdentifierDefault' => 'hf_ident_123']);
+
+        self::assertSame('hf_ident_123', $this->configurationRepository->getPublicKeyId());
+    }
+
+    public function testGetPublicKeyValue_returnsEmptyString(): void
+    {
+        $this->gatewayConfigWith([]);
+
+        self::assertSame('', $this->configurationRepository->getPublicKeyValue());
+    }
+
+    public function testGet_readsArbitraryKeyFromConfig(): void
+    {
+        $this->gatewayConfigWith(['payplug_webhook_authorization_header' => 'Bearer shared-secret']);
+
+        self::assertSame('Bearer shared-secret', $this->configurationRepository->get('payplug_webhook_authorization_header'));
+    }
+
+    public function testGet_whenKeyMissing_returnsNull(): void
+    {
+        $this->gatewayConfigWith([]);
+
+        self::assertNull($this->configurationRepository->get('missing_key'));
+    }
+
+    public function testSet_mergesTheKeyIntoConfigAndFlushes(): void
+    {
+        $gatewayConfig = $this->gatewayConfigWith(['existing' => 'value']);
+        $gatewayConfig->expects(self::once())->method('setConfig')
+            ->with(['existing' => 'value', 'new_key' => 'new_value']);
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $this->configurationRepository->set('new_key', 'new_value');
+    }
+}

--- a/tests/PHPUnit/Upc/SyliusUpcLockTest.php
+++ b/tests/PHPUnit/Upc/SyliusUpcLockTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcLock;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+final class SyliusUpcLockTest extends TestCase
+{
+    private LockFactory&MockObject $lockFactory;
+
+    private SyliusUpcLock $lock;
+
+    protected function setUp(): void
+    {
+        $this->lockFactory = $this->createMock(LockFactory::class);
+        $this->lock = new SyliusUpcLock($this->lockFactory);
+    }
+
+    public function testAcquire_whenLockIsFree_returnsTrue(): void
+    {
+        $lockInterface = $this->createMock(LockInterface::class);
+        $lockInterface->method('acquire')->with(false)->willReturn(true);
+        $this->lockFactory->method('createLock')->with('key', 30)->willReturn($lockInterface);
+
+        self::assertTrue($this->lock->acquire('key', 30));
+    }
+
+    public function testAcquire_whenLockIsHeld_returnsFalse(): void
+    {
+        $lockInterface = $this->createMock(LockInterface::class);
+        $lockInterface->method('acquire')->with(false)->willReturn(false);
+        $this->lockFactory->method('createLock')->willReturn($lockInterface);
+
+        self::assertFalse($this->lock->acquire('key', 30));
+    }
+
+    public function testRelease_releasesAPreviouslyAcquiredLock(): void
+    {
+        $lockInterface = $this->createMock(LockInterface::class);
+        $lockInterface->method('acquire')->willReturn(true);
+        $lockInterface->expects(self::once())->method('release');
+        $this->lockFactory->method('createLock')->willReturn($lockInterface);
+
+        $this->lock->acquire('key', 30);
+        $this->lock->release('key');
+    }
+
+    public function testRelease_whenNothingWasAcquired_doesNothing(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->lock->release('never-acquired');
+    }
+}

--- a/tests/PHPUnit/Upc/SyliusUpcLoggerTest.php
+++ b/tests/PHPUnit/Upc/SyliusUpcLoggerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Upc\SyliusUpcLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class SyliusUpcLoggerTest extends TestCase
+{
+    private LoggerInterface&MockObject $psrLogger;
+
+    private SyliusUpcLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->psrLogger = $this->createMock(LoggerInterface::class);
+        $this->logger = new SyliusUpcLogger($this->psrLogger);
+    }
+
+    public function testDebug_delegatesToThePsrLogger(): void
+    {
+        $this->psrLogger->expects(self::once())->method('debug')->with('a message', ['key' => 'value']);
+
+        $this->logger->debug('a message', ['key' => 'value']);
+    }
+
+    public function testInfo_delegatesToThePsrLogger(): void
+    {
+        $this->psrLogger->expects(self::once())->method('info')->with('a message', []);
+
+        $this->logger->info('a message');
+    }
+
+    public function testError_delegatesToThePsrLogger(): void
+    {
+        $this->psrLogger->expects(self::once())->method('error')->with('a message', ['key' => 'value']);
+
+        $this->logger->error('a message', ['key' => 'value']);
+    }
+}

--- a/tests/PHPUnit/Upc/UnifiedApiHostedPaymentCreatorTest.php
+++ b/tests/PHPUnit/Upc/UnifiedApiHostedPaymentCreatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\PayPlug\SyliusPayPlugPlugin\PHPUnit\Upc;
+
+use PayPlug\SyliusPayPlugPlugin\Upc\UnifiedApiHostedPaymentCreator;
+use PayplugUnifiedCore\Auth\OAuth2Client;
+use PayplugUnifiedCore\Auth\TokenManager;
+use PayplugUnifiedCore\Contracts\IConfigurationRepository;
+use PayplugUnifiedCore\Contracts\IOAuthHttpClient;
+use PayplugUnifiedCore\Contracts\ITokenCache;
+use PayplugUnifiedCore\Contracts\IUnifiedApiHttpClient;
+use PayplugUnifiedCore\Dto\CommonFieldsDto;
+use PayplugUnifiedCore\Dto\HostedFieldDto;
+use PayplugUnifiedCore\Exceptions\ApiException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * TokenManager and OAuth2Client are both `final` (cannot be mocked by PHPUnit), so this test
+ * builds real instances of both, controlling behavior at their actual outer boundary instead:
+ * the injected IOAuthHttpClient (OAuth2 token endpoint) and ITokenCache (caching) — same pattern
+ * as tests/PHPUnit/ApiClient/PayPlugApiClientFactoryTest.php.
+ */
+final class UnifiedApiHostedPaymentCreatorTest extends TestCase
+{
+    private IUnifiedApiHttpClient&MockObject $unifiedApiHttpClient;
+
+    private IOAuthHttpClient&MockObject $oauthHttpClient;
+
+    private ITokenCache&MockObject $tokenCache;
+
+    private IConfigurationRepository&MockObject $configurationRepository;
+
+    private UnifiedApiHostedPaymentCreator $creator;
+
+    protected function setUp(): void
+    {
+        $this->unifiedApiHttpClient = $this->createMock(IUnifiedApiHttpClient::class);
+        $this->oauthHttpClient = $this->createMock(IOAuthHttpClient::class);
+        $this->tokenCache = $this->createMock(ITokenCache::class);
+        $this->configurationRepository = $this->createMock(IConfigurationRepository::class);
+        $this->configurationRepository->method('getClientId')->willReturn('client_abc');
+        $this->configurationRepository->method('getClientSecret')->willReturn('secret_xyz');
+
+        $oauth2Client = new OAuth2Client($this->oauthHttpClient, 'https://api.payplug.com', '', '', 'https://www.payplug.com');
+        $tokenManager = new TokenManager($this->tokenCache, $oauth2Client);
+
+        $this->creator = new UnifiedApiHostedPaymentCreator(
+            $this->unifiedApiHttpClient,
+            $tokenManager,
+            $this->configurationRepository,
+            'https://api.payplug.com',
+        );
+    }
+
+    private function dto(): HostedFieldDto
+    {
+        return new HostedFieldDto(new CommonFieldsDto('acct_123', 1000, 'eur', '42'), 'hf_token_abc');
+    }
+
+    public function testCreateHostedPayment_withValidCredentials_returnsTheOutput(): void
+    {
+        $this->tokenCache->method('get')->willReturn(null);
+        $this->oauthHttpClient->method('post')->willReturn([
+            'status' => 200,
+            'body' => json_encode(['access_token' => 'fresh-jwt', 'expires_in' => 300, 'token_type' => 'Bearer']),
+        ]);
+        $this->unifiedApiHttpClient->method('postJson')->willReturn(['status' => 201, 'body' => '{"id":"pay_1"}']);
+
+        $output = $this->creator->createHostedPayment($this->dto());
+
+        self::assertSame(201, $output->status);
+        self::assertNull($output->redirectUrl);
+    }
+
+    public function testCreateHostedPayment_withPending3ds_extractsTheRedirectUrl(): void
+    {
+        $this->tokenCache->method('get')->willReturn('cached-jwt');
+        $this->unifiedApiHttpClient->method('postJson')->willReturn([
+            'status' => 200,
+            'body' => json_encode(['id' => 'pay_1', 'redirect' => ['url' => 'https://3ds.payplug.com/challenge']]),
+        ]);
+
+        $output = $this->creator->createHostedPayment($this->dto());
+
+        self::assertSame('https://3ds.payplug.com/challenge', $output->redirectUrl);
+    }
+
+    public function testCreateHostedPayment_onNon2xxResponse_throwsApiException(): void
+    {
+        $this->tokenCache->method('get')->willReturn('cached-jwt');
+        $this->unifiedApiHttpClient->method('postJson')->willReturn(['status' => 500, 'body' => '{}']);
+
+        $this->expectException(ApiException::class);
+
+        $this->creator->createHostedPayment($this->dto());
+    }
+}

--- a/tests/PHPUnit/Upc/UnifiedApiHostedPaymentCreatorTest.php
+++ b/tests/PHPUnit/Upc/UnifiedApiHostedPaymentCreatorTest.php
@@ -57,7 +57,7 @@ final class UnifiedApiHostedPaymentCreatorTest extends TestCase
 
     private function dto(): HostedFieldDto
     {
-        return new HostedFieldDto(new CommonFieldsDto('acct_123', 1000, 'eur', '42'), 'hf_token_abc');
+        return new HostedFieldDto(new CommonFieldsDto('acct_123', 1000, 'eur', '42', 'sub_ext_1'), 'hf_token_abc');
     }
 
     public function testCreateHostedPayment_withValidCredentials_returnsTheOutput(): void


### PR DESCRIPTION
## Description

Wires the `payplug_uhf` (Unified Hosted Fields) gateway to actually create and confirm payments through PayPlug's Unified API via UPC (`payplug/unified-plugin-core`), replacing PRE-3550's stub that only stored the hosted-fields token and force-completed checkout without ever calling a payment API.

**Motivation:**

PRE-3550 tokenizes a card client-side into an `hfToken` (+ selected brand + save-card flag) and PRE-3553 added the gateway configuration, but nothing between the two actually creates a payment: `NullHostedFieldsPaymentProcessor` just stores the token on `Payment::details` and bypasses Payum's Capture/Notify/Status pipeline entirely. This PR closes that gap end-to-end: Capture creates the payment via the Unified API, redirects for 3DS/SCA when required, and the asynchronous UPC webhook confirms the final outcome and updates the Sylius payment/order state — with all payment/outcome-mapping logic living in `unified-plugin-core`, not duplicated in the plugin.

**Related issue(s):** Closes PRE-3551

---

## What changed

- **Six new Sylius adapters (`src/Upc/`)** implementing UPC contracts that didn't have one yet:
  - `SyliusUpcLogger` → `ILogger` (wraps the existing `monolog.logger.payplug` channel)
  - `SyliusUpcConfigurationRepository` → `IConfigurationRepository` (reads the `payplug_uhf` gateway's Payum config — OAuth `client_id`/`client_secret`, public key material)
  - `SyliusUnifiedApiHttpClient` → `IUnifiedApiHttpClient` (adapts Symfony's `HttpClientInterface`, same transport-exception handling as `SyliusOAuthHttpClient`)
  - `SyliusUpcLock` → `ILock` (non-blocking wrapper over Symfony `LockFactory`, for webhook idempotency)
  - `SyliusPaymentOperationRepository` → `IPaymentRepository` (backed by the new `PayPlugOperation` entity)
  - `SyliusOrderStateMutator` → `IOrderStateMutator` (maps `PaymentOutcome::*` to Sylius `PaymentTransitions` via the state machine)
- **New `PayPlugOperation` entity** + migration (`Version20260810120000`), persisting each webhook operation (`orderId`, `operationId`, `execCode`, `outcome`, `treated`, `createdAt`) for idempotent webhook processing.
- **Capture pipeline** for `payplug_uhf`: `CaptureHostedPaymentRequest` / `Handler` / `CommandProvider` — builds a `HostedFieldDto` from the stored `hfToken`/`selectedBrand` plus order/customer/browser context, calls `UnifiedApiHostedPaymentService::createHostedPayment()`, and either redirects for 3DS or leaves the payment "processing" pending the webhook.
- **Notify pipeline** for `payplug_uhf`: `NotifyHostedPaymentRequest` / `Handler` / `CommandProvider` — a new, parallel handler (doesn't reuse the legacy `NotifyPaymentRequestHandler`, which is built around the old SDK's response shape). Verifies the webhook via `WebhookNotificationHelper`, guards against concurrent/retried delivery with `ILock`, persists the operation, and applies the outcome via `IOrderStateMutator`.
- **Status pipeline** for `payplug_uhf`: `StatusHostedPaymentRequest` / `Handler` / `CommandProvider` — no polling; just reflects whatever state the webhook has already applied.
- **`PostPaymentSelectEventSubscriber`**: Hosted Fields now redirects to `sylius_shop_order_pay` like every other gateway, instead of the old `sylius_shop_order_show` bypass that skipped Payum entirely.
- **`CaptureHttpResponseProvider`**: tagged for `payplug_uhf` (the tag PRE-3550 left out).
- **`composer.json`**: bumps `payplug/unified-plugin-core` to `1.0.0-rc0` (ships `createHostedPayment()` / `WebhookNotificationHelper`, which this PR depends on).
- **`config/services.yaml`**: wires the six new adapters, the `payplug_uhf` command-provider/http-response-provider services, and new config parameters (`payplug.unified_api_base_url`, `payplug.uhf_account_id`, `payplug.uhf_submerchant_external_id`).

## Known limitations (deferred on purpose)

- No local `Card` persistence for saved UHF cards.
- No status-polling fallback if a webhook is lost — the payment stays pending until resolved manually via the existing `UpdatePaymentStateCommand`.
- Refunds for UHF payments are out of scope (tracked separately as PRE-3552).
- `payplug.uhf_account_id` / `payplug.uhf_submerchant_external_id` are **temporarily hardcoded via env-var defaults** for QA (see the `TEMPORARY (PRE-3551 QA testing)` comments in `config/services.yaml`) — real per-merchant account resolution is a follow-up.
- The new Behat feature (`features/shop/hosted_fields_payment_and_webhook_flow.feature`) documents the two target end-to-end scenarios, but several steps are marked `# NEW — not yet defined`: the Mocker/step-definition infrastructure they need doesn't exist yet, so this file is **not runnable as-is**.
- No change to the legacy `payplug`/Oney/Bancontact/Scalapay/Apple Pay/American Express gateways — they keep using the existing `PayPlugApiClient` SDK flow untouched.

---

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality) 
- [x] 📦 Dependency update [x]

---

## Checklist
### Code Quality
- [x] Code is linted and formatted
- [x] No unnecessary commented-out code or debug logs
- [ ] No hardcoded values (use env variables or config) — see "Known limitations": `uhf_account_id`/`uhf_submerchant_external_id` are intentionally hardcoded via env-var defaults for this QA phase

### Testing
- [x] Unit tests added / updated — one test class per new `src/Upc/` adapter and per new Capture/Notify/Status handler, covering the redirect vs. no-redirect branches, API exceptions, lock contention, and already-treated webhook replay
- [ ] Behat scenarios are written but not yet executable (see "Known limitations")

### Security & Ops
- [x] No sensitive data or secrets introduced
- [x] Logging and error handling are appropriate — webhook failures are logged and the lock is always released in a `finally`; Capture-time API errors fail the payment through the standard checkout error path
